### PR TITLE
Vercel transport cleanup, Fix up exclusion pathways + optimize readdir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ import type { Backend, FileBasedBackend } from './types.js'
 import { LocalFilesystemBackend } from './backends/LocalFilesystemBackend.js'
 ```
 
+- No inline `@import`. Use static imports at the top. 
+
 ## Testing
 
 ### Unit Tests (Vitest)

--- a/examples/NextJS/app/api/chat/route.ts
+++ b/examples/NextJS/app/api/chat/route.ts
@@ -8,7 +8,11 @@ export async function POST(req: Request) {
   // Get AI SDK MCP client (cached per session, cleared on backend config change)
   // Tools are already in AI SDK format - no manual transformation needed
   const mcpClient = await getMCPClientForSession(sessionId)
-  const tools = await mcpClient.tools()
+
+  // Cast needed due to TypeScript incompatibility between @ai-sdk/mcp and ai package
+  // (FlexibleSchema<unknown> vs FlexibleSchema<never>) - runtime works fine
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tools = await mcpClient.tools() as any
 
   // Convert UI messages to model messages
   const modelMessages = await convertToModelMessages(messages, { tools })

--- a/examples/NextJS/app/lib/mcp-client.ts
+++ b/examples/NextJS/app/lib/mcp-client.ts
@@ -1,9 +1,11 @@
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp'
 import { VercelAIAdapter } from 'agent-backend'
 import { backendManager } from './backend'
 
+// MCP client type from VercelAIAdapter
+type MCPClient = Awaited<ReturnType<VercelAIAdapter['getMCPClient']>>
+
 // MCP client cache - stores AI SDK MCP clients per session
-const mcpClientCache = new Map<string, Awaited<ReturnType<typeof createMCPClient>>>()
+const mcpClientCache = new Map<string, MCPClient>()
 
 /**
  * Clear all cached MCP clients (call when backend config changes)
@@ -30,7 +32,7 @@ export async function getMCPClientForSession(sessionId: string) {
     return mcpClientCache.get(sessionId)!
   }
 
-  const client = await createAIMCPClient()
+  const client = await createMCPClient()
   mcpClientCache.set(sessionId, client)
   return client
 }
@@ -38,23 +40,17 @@ export async function getMCPClientForSession(sessionId: string) {
 /**
  * Create an AI SDK MCP client using the configured backend.
  *
- * Uses VercelAIAdapter to get the appropriate transport:
+ * Uses VercelAIAdapter which automatically selects the right transport:
  * - LocalFilesystemBackend → StdioClientTransport (spawns subprocess)
  * - RemoteFilesystemBackend → StreamableHTTPClientTransport (HTTP)
  * - MemoryBackend → StdioClientTransport (spawns subprocess)
- *
- * The returned client has tools already in AI SDK format.
  */
-async function createAIMCPClient() {
+async function createMCPClient() {
   const backend = await backendManager.getBackend()
   console.log('[mcp-client] Creating AI SDK MCP client for backend type:', backend.type)
 
-  // Use VercelAIAdapter to get the transport
   const adapter = new VercelAIAdapter(backend)
-  const transport = await adapter.getTransport()
-
-  // Create AI SDK MCP client with the transport
-  const client = await createMCPClient({ transport })
+  const client = await adapter.getMCPClient()
 
   console.log('[mcp-client] AI SDK MCP client created')
   return client

--- a/typescript/eslint.config.js
+++ b/typescript/eslint.config.js
@@ -23,6 +23,7 @@ export default [
         module: 'readonly',
         NodeJS: 'readonly',
         BufferEncoding: 'readonly',
+        URL: 'readonly'
       },
     },
     plugins: {

--- a/typescript/src/adapters/index.ts
+++ b/typescript/src/adapters/index.ts
@@ -1,2 +1,1 @@
 export { VercelAIAdapter } from './VercelAIAdapter.js'
-export type { MCPTransport } from './VercelAIAdapter.js'

--- a/typescript/src/backends/ScopedFilesystemBackend.ts
+++ b/typescript/src/backends/ScopedFilesystemBackend.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { Stats } from 'fs'
 import * as path from 'path'
 import type { OperationsLogger } from '../logging/types.js'
@@ -139,6 +140,13 @@ export class ScopedFilesystemBackend<T extends FileBasedBackend = FileBasedBacke
   }
 
   /**
+   * List directory contents with stats in scoped directory
+   */
+  async readdirWithStats(relativePath: string): Promise<{ name: string, stats: Stats }[]> {
+    return this.parent.readdirWithStats(this.toParentPath(relativePath))
+  }
+
+  /**
    * Create directory in scoped directory
    */
   async mkdir(relativePath: string, options?: { recursive?: boolean }): Promise<void> {
@@ -201,6 +209,18 @@ export class ScopedFilesystemBackend<T extends FileBasedBackend = FileBasedBacke
     }
 
     return scopes
+  }
+
+  /**
+   * Get MCP transport for this scoped backend.
+   * Can be used directly with Vercel AI SDK's createMCPClient or raw MCP SDK.
+   */
+  async getMCPTransport(additionalScopePath?: string): Promise<Transport> {
+    const fullScopePath = additionalScopePath
+      ? path.join(this.scopePath, additionalScopePath)
+      : this.scopePath
+
+    return this.parent.getMCPTransport(fullScopePath)
   }
 
   /**

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -35,6 +35,7 @@ export { BackendType } from './backends/types.js'
 export type {
     Backend,
     FileBasedBackend,
+    MCPTransport,
     ScopedBackend
 } from './backends/types.js'
 
@@ -79,12 +80,22 @@ export {
     type CreateMCPClientOptions
 } from './mcp/client.js'
 
+// Local/memory transport helpers
+export {
+    createLocalMCPTransportOptions,
+    createMemoryMCPTransportOptions,
+    type LocalMCPTransportOptions,
+    type MemoryMCPTransportOptions,
+} from './mcp/local-transport.js'
+
+// Centralized backend transport creation
+export { createBackendMCPTransport } from './mcp/transport.js'
+
 // ============================================================================
 // Adapters
 // ============================================================================
 
 export { VercelAIAdapter } from './adapters/index.js'
-export type { MCPTransport } from './adapters/index.js'
 
 // ============================================================================
 // Type Guards & Utilities
@@ -97,3 +108,10 @@ export {
     isFileBasedBackend,
     isScopedBackend,
 } from './typing.js'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Default patterns for excluding directories from tree listings
+export { DEFAULT_EXCLUDE_PATTERNS } from './server/tools.js'

--- a/typescript/src/mcp/index.ts
+++ b/typescript/src/mcp/index.ts
@@ -1,4 +1,15 @@
 // MCP Client helpers for connecting to MCP servers
 export { createAgentBeMCPClient, createAgentBeMCPTransport, type AgentBeMCPClient, type AgentBeMCPClientOptions } from './client.js'
 
+// Local/memory transport helpers
+export {
+  createLocalMCPTransportOptions,
+  createMemoryMCPTransportOptions,
+  type LocalMCPTransportOptions,
+  type MemoryMCPTransportOptions,
+} from './local-transport.js'
+
+// Centralized backend transport creation
+export { createBackendMCPTransport, type MCPTransport } from './transport.js'
+
 // Note: MCP server implementation is available at 'agent-backend/server'

--- a/typescript/src/mcp/local-transport.ts
+++ b/typescript/src/mcp/local-transport.ts
@@ -1,0 +1,69 @@
+import type { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js'
+
+export interface LocalMCPTransportOptions {
+  /** Root directory for the MCP server */
+  rootDir: string
+  /** Isolation mode (optional) */
+  isolation?: 'auto' | 'bwrap' | 'software' | 'none'
+  /** Shell to use (optional) */
+  shell?: string
+}
+
+/**
+ * Create options for a local MCP stdio transport.
+ * Use this with StdioClientTransport from @modelcontextprotocol/sdk.
+ *
+ * @example
+ * ```typescript
+ * import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+ * import { createLocalMCPTransportOptions } from 'agent-backend'
+ *
+ * const options = createLocalMCPTransportOptions({
+ *   rootDir: '/tmp/workspace',
+ *   isolation: 'software',
+ * })
+ * const transport = new StdioClientTransport(options)
+ * ```
+ */
+export function createLocalMCPTransportOptions(
+  options: LocalMCPTransportOptions
+): StdioServerParameters {
+  const args = [
+    'daemon',
+    '--rootDir', options.rootDir,
+    '--local-only',
+  ]
+
+  if (options.isolation && options.isolation !== 'auto') {
+    args.push('--isolation', options.isolation)
+  }
+
+  if (options.shell && options.shell !== 'auto') {
+    args.push('--shell', options.shell)
+  }
+
+  return {
+    command: 'agent-backend',
+    args,
+  }
+}
+
+export interface MemoryMCPTransportOptions {
+  /** Root directory/namespace for the memory backend */
+  rootDir: string
+}
+
+/**
+ * Create options for a memory backend MCP stdio transport.
+ */
+export function createMemoryMCPTransportOptions(
+  options: MemoryMCPTransportOptions
+): StdioServerParameters {
+  return {
+    command: 'agent-backend',
+    args: [
+      '--backend', 'memory',
+      '--rootDir', options.rootDir,
+    ],
+  }
+}

--- a/typescript/src/mcp/transport.ts
+++ b/typescript/src/mcp/transport.ts
@@ -1,0 +1,133 @@
+/**
+ * Centralized MCP transport creation for backends.
+ *
+ * This module provides the core logic for creating MCP transports
+ * based on backend type. Used by backends to implement getMCPTransport().
+ */
+
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { Backend } from '../backends/types.js'
+import { BackendType } from '../backends/types.js'
+import { ERROR_CODES } from '../constants.js'
+import { BackendError } from '../types.js'
+import {
+  getProperty,
+  getRootBackend,
+  hasRemoteConfig,
+  isFileBasedBackend,
+} from '../typing.js'
+import { createAgentBeMCPTransport } from './client.js'
+import { createLocalMCPTransportOptions, createMemoryMCPTransportOptions } from './local-transport.js'
+
+/**
+ * Union type for MCP transports
+ */
+export type MCPTransport = StdioClientTransport | StreamableHTTPClientTransport
+
+/**
+ * Create an MCP transport for a backend.
+ *
+ * This is the centralized implementation used by all backends.
+ * Transport type depends on backend type:
+ * - LocalFilesystemBackend → StdioClientTransport (spawns subprocess)
+ * - RemoteFilesystemBackend → StreamableHTTPClientTransport (HTTP)
+ * - MemoryBackend → StdioClientTransport (spawns subprocess)
+ *
+ * @param backend - The backend to create a transport for
+ * @param scopePath - Optional scope path to override rootDir
+ * @returns MCP transport configured for the backend type
+ */
+export async function createBackendMCPTransport(
+  backend: Backend,
+  scopePath?: string
+): Promise<MCPTransport> {
+  const rootBackend = getRootBackend(backend)
+  const backendType = rootBackend.type
+
+  switch (backendType) {
+    case BackendType.LOCAL_FILESYSTEM:
+      return createLocalTransport(backend, rootBackend, scopePath)
+
+    case BackendType.REMOTE_FILESYSTEM:
+      return createRemoteTransport(backend, rootBackend, scopePath)
+
+    case BackendType.MEMORY:
+      return createMemoryTransport(backend, scopePath)
+
+    default:
+      throw new BackendError(
+        `Unsupported backend type: ${backendType}. getMCPTransport supports LOCAL_FILESYSTEM, REMOTE_FILESYSTEM, and MEMORY backends.`,
+        ERROR_CODES.INVALID_CONFIGURATION,
+        'unsupported-backend-type'
+      )
+  }
+}
+
+/**
+ * Create Stdio transport for local filesystem backend
+ */
+async function createLocalTransport(
+  backend: Backend,
+  rootBackend: Backend,
+  scopePath?: string
+): Promise<StdioClientTransport> {
+  const defaultRootDir = isFileBasedBackend(backend) ? backend.rootDir : '/'
+  const rootDir = scopePath || defaultRootDir
+  const isolation = getProperty<string>(rootBackend, 'isolation') ||
+                    getProperty<string>(rootBackend, 'actualIsolation')
+  const shell = getProperty<string>(rootBackend, 'shell')
+
+  const options = createLocalMCPTransportOptions({
+    rootDir,
+    isolation: isolation as 'auto' | 'bwrap' | 'software' | 'none' | undefined,
+    shell,
+  })
+
+  return new StdioClientTransport(options)
+}
+
+/**
+ * Create HTTP transport for remote filesystem backend
+ */
+async function createRemoteTransport(
+  backend: Backend,
+  rootBackend: Backend,
+  scopePath?: string
+): Promise<StreamableHTTPClientTransport> {
+  if (!hasRemoteConfig(rootBackend)) {
+    throw new BackendError(
+      'RemoteFilesystemBackend requires host to be configured. ' +
+      'The MCP server must run on the remote host and be accessible via HTTP.',
+      ERROR_CODES.INVALID_CONFIGURATION,
+      'host'
+    )
+  }
+
+  const { config } = rootBackend
+  const mcpHost = config.mcpServerHostOverride || config.host
+  const mcpPort = config.mcpPort || 3001
+  const defaultRootDir = isFileBasedBackend(backend) ? backend.rootDir : '/'
+
+  return createAgentBeMCPTransport({
+    url: `http://${mcpHost}:${mcpPort}`,
+    authToken: config.mcpAuth?.token || '',
+    workspaceRoot: scopePath || defaultRootDir,
+    userId: '',
+    workspace: '',
+  })
+}
+
+/**
+ * Create Stdio transport for memory backend
+ */
+async function createMemoryTransport(
+  backend: Backend,
+  scopePath?: string
+): Promise<StdioClientTransport> {
+  const defaultRootDir = isFileBasedBackend(backend) ? backend.rootDir : '/'
+  const rootDir = scopePath || defaultRootDir
+  const options = createMemoryMCPTransportOptions({ rootDir })
+
+  return new StdioClientTransport(options)
+}

--- a/typescript/src/server/index.ts
+++ b/typescript/src/server/index.ts
@@ -10,4 +10,4 @@
  */
 
 export { AgentBackendMCPServer } from './AgentBackendMCPServer.js'
-export { registerFilesystemTools, registerExecTool } from './tools.js'
+export { registerFilesystemTools, registerExecTool, DEFAULT_EXCLUDE_PATTERNS } from './tools.js'

--- a/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
@@ -155,6 +155,18 @@ describe('ScopedFilesystemBackend (Unit Tests)', () => {
       expect(mockParent.readdir).toHaveBeenCalledWith('users/user1/subdir')
     })
 
+    it('should delegate readdirWithStats to parent with scoped path', async () => {
+      const mockEntries = [
+        { name: 'file.txt', stats: { isFile: () => true, size: 100 } }
+      ]
+      vi.mocked(mockParent.readdirWithStats).mockResolvedValue(mockEntries as any)
+
+      const entries = await scoped.readdirWithStats('subdir')
+
+      expect(mockParent.readdirWithStats).toHaveBeenCalledWith('users/user1/subdir')
+      expect(entries).toEqual(mockEntries)
+    })
+
     it('should delegate mkdir to parent with scoped path', async () => {
       await scoped.mkdir('newdir', { recursive: true })
 

--- a/typescript/tests/unit/helpers/mockFactories.ts
+++ b/typescript/tests/unit/helpers/mockFactories.ts
@@ -103,6 +103,7 @@ export function createMockFileBackend(overrides: Partial<FileBasedBackend> = {})
     read: vi.fn().mockResolvedValue('mock content'),
     write: vi.fn().mockResolvedValue(undefined),
     readdir: vi.fn().mockResolvedValue([]),
+    readdirWithStats: vi.fn().mockResolvedValue([]),
     mkdir: vi.fn().mockResolvedValue(undefined),
     exists: vi.fn().mockResolvedValue(true),
     stat: vi.fn().mockResolvedValue({
@@ -117,6 +118,7 @@ export function createMockFileBackend(overrides: Partial<FileBasedBackend> = {})
     scope: vi.fn().mockReturnValue(null as any),
     listScopes: vi.fn().mockResolvedValue([]),
     getMCPClient: vi.fn(),
+    getMCPTransport: vi.fn(),
     destroy: vi.fn().mockResolvedValue(undefined),
     ...overrides
   } as FileBasedBackend
@@ -133,6 +135,7 @@ export function createMockMemoryBackend(overrides: Partial<MemoryBackend> = {}):
     read: vi.fn().mockResolvedValue('mock content'),
     write: vi.fn().mockResolvedValue(undefined),
     readdir: vi.fn().mockResolvedValue([]),
+    readdirWithStats: vi.fn().mockResolvedValue([]),
     mkdir: vi.fn().mockResolvedValue(undefined),
     exists: vi.fn().mockResolvedValue(true),
     stat: vi.fn().mockResolvedValue({
@@ -146,6 +149,7 @@ export function createMockMemoryBackend(overrides: Partial<MemoryBackend> = {}):
     scope: vi.fn().mockReturnValue(null as any),
     listScopes: vi.fn().mockResolvedValue([]),
     getMCPClient: vi.fn(),
+    getMCPTransport: vi.fn(),
     destroy: vi.fn().mockResolvedValue(undefined),
     list: vi.fn().mockResolvedValue([]),
     delete: vi.fn().mockResolvedValue(undefined),

--- a/typescript/tests/unit/mcp/transport.test.ts
+++ b/typescript/tests/unit/mcp/transport.test.ts
@@ -1,0 +1,288 @@
+import * as fsSync from 'fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LocalFilesystemBackend } from '../../../src/backends/LocalFilesystemBackend.js'
+import { MemoryBackend } from '../../../src/backends/MemoryBackend.js'
+import { RemoteFilesystemBackend } from '../../../src/backends/RemoteFilesystemBackend.js'
+import { BackendType } from '../../../src/backends/types.js'
+import { createBackendMCPTransport } from '../../../src/mcp/transport.js'
+import { BackendError } from '../../../src/types.js'
+
+// Mock the MCP SDK transports
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation((options) => ({
+    type: 'stdio',
+    options,
+  })),
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation((url, options) => ({
+    type: 'http',
+    url,
+    options,
+  })),
+}))
+
+describe('MCP Transport (Unit Tests)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock mkdirSync for LocalFilesystemBackend constructor
+    vi.mocked(fsSync.mkdirSync).mockReturnValue(undefined)
+  })
+
+  describe('createBackendMCPTransport', () => {
+    describe('LocalFilesystemBackend', () => {
+      it('should create StdioClientTransport for local backend', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const transport = await createBackendMCPTransport(backend)
+
+        expect(transport).toBeDefined()
+        expect((transport as any).type).toBe('stdio')
+        expect((transport as any).options.command).toBe('agent-backend')
+        expect((transport as any).options.args).toContain('daemon')
+        expect((transport as any).options.args).toContain('--rootDir')
+        expect((transport as any).options.args).toContain('/test/workspace')
+        expect((transport as any).options.args).toContain('--local-only')
+      })
+
+      it('should include isolation flag when not auto', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const transport = await createBackendMCPTransport(backend)
+
+        expect((transport as any).options.args).toContain('--isolation')
+        expect((transport as any).options.args).toContain('software')
+      })
+
+      it('should include shell flag when not auto', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'sh',
+        })
+
+        const transport = await createBackendMCPTransport(backend)
+
+        expect((transport as any).options.args).toContain('--shell')
+        expect((transport as any).options.args).toContain('sh')
+      })
+
+      it('should use scopePath when provided', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const transport = await createBackendMCPTransport(backend, '/custom/scope')
+
+        expect((transport as any).options.args).toContain('/custom/scope')
+        expect((transport as any).options.args).not.toContain('/test/workspace')
+      })
+    })
+
+    describe('MemoryBackend', () => {
+      it('should create StdioClientTransport for memory backend', async () => {
+        const backend = new MemoryBackend({ rootDir: '/memory' })
+
+        const transport = await createBackendMCPTransport(backend)
+
+        expect(transport).toBeDefined()
+        expect((transport as any).type).toBe('stdio')
+        expect((transport as any).options.command).toBe('agent-backend')
+        expect((transport as any).options.args).toContain('--backend')
+        expect((transport as any).options.args).toContain('memory')
+        expect((transport as any).options.args).toContain('--rootDir')
+        expect((transport as any).options.args).toContain('/memory')
+      })
+
+      it('should use scopePath when provided', async () => {
+        const backend = new MemoryBackend({ rootDir: '/memory' })
+
+        const transport = await createBackendMCPTransport(backend, '/scoped/path')
+
+        expect((transport as any).options.args).toContain('/scoped/path')
+      })
+    })
+
+    describe('RemoteFilesystemBackend', () => {
+      it('should create StreamableHTTPClientTransport for remote backend', async () => {
+        // Create a mock remote backend with config
+        const mockBackend = {
+          type: BackendType.REMOTE_FILESYSTEM,
+          connected: true,
+          rootDir: '/remote/workspace',
+          config: {
+            host: 'remote.example.com',
+            mcpPort: 3001,
+            mcpAuth: { token: 'test-token' },
+          },
+          getMCPTransport: vi.fn(),
+          getMCPClient: vi.fn(),
+          destroy: vi.fn(),
+        }
+
+        const transport = await createBackendMCPTransport(mockBackend as any)
+
+        expect(transport).toBeDefined()
+        expect((transport as any).type).toBe('http')
+        expect((transport as any).url.toString()).toBe('http://remote.example.com:3001/mcp')
+      })
+
+      it('should throw error when host is not configured', async () => {
+        const mockBackend = {
+          type: BackendType.REMOTE_FILESYSTEM,
+          connected: true,
+          rootDir: '/remote/workspace',
+          config: {
+            // No host configured
+          },
+          getMCPTransport: vi.fn(),
+          getMCPClient: vi.fn(),
+          destroy: vi.fn(),
+        }
+
+        await expect(createBackendMCPTransport(mockBackend as any)).rejects.toThrow(BackendError)
+        await expect(createBackendMCPTransport(mockBackend as any)).rejects.toThrow('host')
+      })
+
+      it('should use mcpServerHostOverride when provided', async () => {
+        const mockBackend = {
+          type: BackendType.REMOTE_FILESYSTEM,
+          connected: true,
+          rootDir: '/remote/workspace',
+          config: {
+            host: 'original.example.com',
+            mcpServerHostOverride: 'override.example.com',
+            mcpPort: 4000,
+            mcpAuth: { token: 'test-token' },
+          },
+          getMCPTransport: vi.fn(),
+          getMCPClient: vi.fn(),
+          destroy: vi.fn(),
+        }
+
+        const transport = await createBackendMCPTransport(mockBackend as any)
+
+        expect((transport as any).url.toString()).toBe('http://override.example.com:4000/mcp')
+      })
+    })
+
+    describe('Unsupported backend types', () => {
+      it('should throw error for unsupported backend type', async () => {
+        const mockBackend = {
+          type: 'unsupported-type' as any,
+          connected: true,
+          getMCPTransport: vi.fn(),
+          getMCPClient: vi.fn(),
+          destroy: vi.fn(),
+        }
+
+        await expect(createBackendMCPTransport(mockBackend as any)).rejects.toThrow(BackendError)
+        await expect(createBackendMCPTransport(mockBackend as any)).rejects.toThrow('Unsupported backend type')
+      })
+    })
+  })
+
+  describe('Backend.getMCPTransport()', () => {
+    describe('LocalFilesystemBackend', () => {
+      it('should return transport via getMCPTransport()', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const transport = await backend.getMCPTransport()
+
+        expect(transport).toBeDefined()
+        expect((transport as any).type).toBe('stdio')
+      })
+
+      it('should pass scopePath to transport', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const transport = await backend.getMCPTransport('/scoped/path')
+
+        expect((transport as any).options.args).toContain('/scoped/path')
+      })
+    })
+
+    describe('MemoryBackend', () => {
+      it('should return transport via getMCPTransport()', async () => {
+        const backend = new MemoryBackend({ rootDir: '/memory' })
+
+        const transport = await backend.getMCPTransport()
+
+        expect(transport).toBeDefined()
+        expect((transport as any).type).toBe('stdio')
+        expect((transport as any).options.args).toContain('memory')
+      })
+
+      it('should pass scopePath to transport', async () => {
+        const backend = new MemoryBackend({ rootDir: '/memory' })
+
+        const transport = await backend.getMCPTransport('/scoped/memory')
+
+        expect((transport as any).options.args).toContain('/scoped/memory')
+      })
+    })
+
+    describe('ScopedFilesystemBackend', () => {
+      it('should delegate to parent with combined scope path', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const scoped = backend.scope('user123')
+        const transport = await scoped.getMCPTransport()
+
+        expect(transport).toBeDefined()
+        expect((transport as any).options.args).toContain('user123')
+      })
+
+      it('should combine additional scope path', async () => {
+        const backend = new LocalFilesystemBackend({
+          rootDir: '/test/workspace',
+          isolation: 'software',
+          shell: 'bash',
+        })
+
+        const scoped = backend.scope('user123')
+        const transport = await scoped.getMCPTransport('projects')
+
+        // Should combine: user123 + projects
+        expect(transport).toBeDefined()
+        expect((transport as any).options.args).toContain('user123/projects')
+      })
+    })
+
+    describe('ScopedMemoryBackend', () => {
+      it('should delegate to parent with combined scope path', async () => {
+        const backend = new MemoryBackend({ rootDir: '/memory' })
+
+        const scoped = backend.scope('user123')
+        const transport = await scoped.getMCPTransport()
+
+        expect(transport).toBeDefined()
+        // ScopedMemoryBackend adds trailing slash to scopePath
+        expect((transport as any).options.args).toContain('user123/')
+      })
+    })
+  })
+})

--- a/typescript/tests/unit/server/AgentBackendMCPServer.test.ts
+++ b/typescript/tests/unit/server/AgentBackendMCPServer.test.ts
@@ -426,4 +426,25 @@ describe('AgentBackendMCPServer (Adaptive Server)', () => {
       expect(() => new AgentBackendMCPServer(memoryBackend)).not.toThrow()
     })
   })
+
+  describe('directory_tree Tool', () => {
+    it('should register directory_tree tool', () => {
+      const backend = createMockFileBackend('LocalFilesystem')
+      const server = new AgentBackendMCPServer(backend)
+      const tools = server.server.getTools()
+
+      expect(Object.keys(tools)).toContain('directory_tree')
+    })
+
+    it('should have includeDefaultExcludes parameter defined', () => {
+      const backend = createMockFileBackend('LocalFilesystem')
+      const server = new AgentBackendMCPServer(backend)
+      const tools = server.server.getTools()
+      const dirTreeTool = tools['directory_tree']
+
+      expect(dirTreeTool).toBeDefined()
+      // The tool has inputSchema with path, excludePatterns, and includeDefaultExcludes
+      expect(dirTreeTool.inputSchema).toBeDefined()
+    })
+  })
 })

--- a/typescript/tests/unit/server/exclude-patterns.test.ts
+++ b/typescript/tests/unit/server/exclude-patterns.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../../src/server/tools.js'
+
+describe('DEFAULT_EXCLUDE_PATTERNS', () => {
+  describe('Pattern Contents', () => {
+    it('should be exported and be an array', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toBeDefined()
+      expect(Array.isArray(DEFAULT_EXCLUDE_PATTERNS)).toBe(true)
+      expect(DEFAULT_EXCLUDE_PATTERNS.length).toBeGreaterThan(0)
+    })
+
+    it('should include common dependency directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('node_modules')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.venv')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('venv')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('__pycache__')
+    })
+
+    it('should include version control directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.git')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.svn')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.hg')
+    })
+
+    it('should include build artifact directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('dist')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('build')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.next')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('target')
+    })
+
+    it('should include cache directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.cache')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.pytest_cache')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.mypy_cache')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.ruff_cache')
+    })
+
+    it('should include coverage directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('coverage')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.coverage')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('htmlcov')
+    })
+
+    it('should include IDE directories', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.idea')
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('.vscode')
+    })
+
+    it('should include glob patterns for egg-info', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('*.egg-info')
+    })
+  })
+
+  describe('Pattern Matching Behavior', () => {
+    // Helper to check if a name matches any pattern
+    function matchesExcludePattern(name: string): boolean {
+      return DEFAULT_EXCLUDE_PATTERNS.some(pattern => {
+        if (pattern.includes('*')) {
+          // Simple glob matching for *.suffix patterns
+          if (pattern.startsWith('*.')) {
+            return name.endsWith(pattern.slice(1))
+          }
+          return false
+        }
+        return name === pattern
+      })
+    }
+
+    it('should match exact directory names', () => {
+      expect(matchesExcludePattern('node_modules')).toBe(true)
+      expect(matchesExcludePattern('.git')).toBe(true)
+      expect(matchesExcludePattern('.venv')).toBe(true)
+    })
+
+    it('should not match partial names', () => {
+      expect(matchesExcludePattern('my_node_modules')).toBe(false)
+      expect(matchesExcludePattern('node_modules_backup')).toBe(false)
+      expect(matchesExcludePattern('venv2')).toBe(false)
+    })
+
+    it('should match glob patterns like *.egg-info', () => {
+      expect(matchesExcludePattern('mypackage.egg-info')).toBe(true)
+      expect(matchesExcludePattern('another-pkg.egg-info')).toBe(true)
+    })
+
+    it('should not match regular files or directories', () => {
+      expect(matchesExcludePattern('src')).toBe(false)
+      expect(matchesExcludePattern('README.md')).toBe(false)
+      expect(matchesExcludePattern('package.json')).toBe(false)
+      expect(matchesExcludePattern('app')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description
- virtualenv in subdirs was super slow, so made more robust exclusion pathways feature + an optimized readdir method with stats
- Vercel transport code was wonky and probably incorrect. Fixed according to the old constellationFS impl.