### PR TITLE
feat: Implement ssh over websockets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,15 +5,24 @@
 
 # All values are optional - CLI defaults will be used if not set:
 #   MCP_PORT: 3001
-#   SSH_USERS: root:agents
+#   AUTH_TOKEN: (none - auth disabled)
+#   SSH-WS: enabled by default
 
 # Workspace directory inside container (must match volume mount in mprocs.yaml)
 WORKSPACE_ROOT=/var/workspace
 
-# MCP server configuration
-# MCP_PORT=3001
-# MCP_AUTH_TOKEN=your-secret-token
+# Unified authentication (used for both MCP and SSH-WS)
+# AUTH_TOKEN=your-secret-token
 
-# SSH configuration
+# MCP + SSH-WS server configuration
+# MCP_PORT=3001
+
+# SSH-WS is enabled by default. To disable:
+# DISABLE_SSH_WS=true
+
+# === Conventional SSH (opt-in) ===
+# Enable conventional sshd for legacy clients or debugging
+# CONVENTIONAL_SSH=true
+# SSH_PORT=22
 # SSH_USERS=root:agents
 # SSH_PUBLIC_KEY=ssh-rsa AAAAB3N...

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+; Allow native module builds for ws performance packages
+onlyBuiltDependencies[]=bufferutil
+onlyBuiltDependencies[]=utf-8-validate
+onlyBuiltDependencies[]=cpu-features

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -84,13 +84,3 @@ const resolved = validateWithinBoundary(userPath, boundary, pathModule)
 ```
 
 For SFTP operations (SSH-WS transport), the server-side `SFTPHandler.ts` also implements these conventions to ensure paths sent from clients are handled correctly.
-
-### Testing
-
-Path handling is tested comprehensively in:
-- `tests/unit/backends/pathValidation.test.ts` - Core validation logic (34 tests)
-- `tests/unit/backends/LocalFilesystemBackend.test.ts` - Path validation section
-- `tests/unit/backends/ScopedFilesystemBackend.test.ts` - Scope boundary tests
-- `tests/unit/backends/RemoteFilesystemBackend.test.ts` - Remote path handling
-
-When adding new backends or modifying path handling, ensure all three cases are covered by tests.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,96 @@
+# Conventions
+
+This document describes project-wide conventions that apply across the agent-backend ecosystem.
+
+## Path Handling
+
+All file-based backends follow consistent path handling conventions. These conventions ensure flexibility while maintaining security through path escape prevention.
+
+### The Three Cases
+
+1. **Relative paths** (e.g., `.`, `file.txt`, `subdir/file.txt`)
+   - Resolved relative to the workspace root (rootDir or scope)
+   - Examples:
+     - `file.txt` → `/var/workspace/file.txt`
+     - `subdir/file.txt` → `/var/workspace/subdir/file.txt`
+     - `.` → `/var/workspace`
+
+2. **Absolute paths matching workspace** (e.g., `/var/workspace/file.txt` when rootDir is `/var/workspace`)
+   - Used directly since they're already within the workspace
+   - Validated to ensure they don't escape the boundary
+   - Examples:
+     - `/var/workspace/file.txt` → `/var/workspace/file.txt`
+     - `/var/workspace/a/b/c` → `/var/workspace/a/b/c`
+
+3. **Absolute paths not matching workspace** (e.g., `/other/file.txt`)
+   - Treated as relative to the workspace (leading slashes stripped)
+   - This prevents accidental access to system paths while allowing absolute-style references
+   - Examples:
+     - `/file.txt` → `/var/workspace/file.txt`
+     - `/etc/passwd` → `/var/workspace/etc/passwd`
+
+### Security: Path Escape Prevention
+
+All paths are validated to ensure they stay within the workspace boundary:
+
+```typescript
+// These are REJECTED with PathEscapeError:
+'../etc/passwd'           // Escapes via parent directory
+'../../..'                // Escapes to filesystem root
+'a/b/../../../../etc'     // Escapes via complex traversal
+```
+
+The validation happens at multiple layers:
+- `validateWithinBoundary()` in `pathValidation.ts` (shared utility)
+- Each backend's `resolvePath()` method
+- Scoped backends add an additional layer of validation against the scope boundary
+
+### Scoped Workspaces
+
+Scoped backends (created via `backend.scope('subdir')`) follow the same conventions, but the boundary is the scope's full path (parent rootDir + scopePath):
+
+```typescript
+const backend = new LocalFilesystemBackend({ rootDir: '/var/workspace' })
+const scoped = backend.scope('users/user1')
+
+// Scope rootDir is now /var/workspace/users/user1
+scoped.read('file.txt')                              // → users/user1/file.txt (relative to parent)
+scoped.read('/file.txt')                             // → users/user1/file.txt (absolute treated as relative)
+scoped.read('/var/workspace/users/user1/file.txt')   // → users/user1/file.txt (absolute matching scope rootDir)
+scoped.read('../user2/secret')                       // → PathEscapeError (escapes scope)
+```
+
+Scoped backends validate paths against their full `rootDir` (e.g., `/var/workspace/users/user1`), so absolute paths that include the full path work correctly. This is implemented in both `ScopedFilesystemBackend` and `ScopedMemoryBackend`.
+
+### Backend-Specific Notes
+
+| Backend | Path Module | Notes |
+|---------|-------------|-------|
+| `LocalFilesystemBackend` | Native `path` | Uses OS-specific path handling |
+| `RemoteFilesystemBackend` | `path.posix` | Always uses POSIX paths for remote Unix systems |
+| `ScopedFilesystemBackend` | Inherits from parent | Adds scope boundary validation |
+| `MemoryBackend` | `path.posix` | Keys are treated as paths |
+| `ScopedMemoryBackend` | `path.posix` | Adds scope prefix validation |
+
+### Implementation Details
+
+The core path validation logic is in `src/backends/pathValidation.ts`:
+
+```typescript
+import { validateWithinBoundary } from './pathValidation.js'
+
+// Returns combined path if valid, throws PathEscapeError if not
+const resolved = validateWithinBoundary(userPath, boundary, pathModule)
+```
+
+For SFTP operations (SSH-WS transport), the server-side `SFTPHandler.ts` also implements these conventions to ensure paths sent from clients are handled correctly.
+
+### Testing
+
+Path handling is tested comprehensively in:
+- `tests/unit/backends/pathValidation.test.ts` - Core validation logic (34 tests)
+- `tests/unit/backends/LocalFilesystemBackend.test.ts` - Path validation section
+- `tests/unit/backends/ScopedFilesystemBackend.test.ts` - Scope boundary tests
+- `tests/unit/backends/RemoteFilesystemBackend.test.ts` - Remote path handling
+
+When adding new backends or modifying path handling, ensure all three cases are covered by tests.

--- a/examples/NextJS/app/components/BackendSettings.tsx
+++ b/examples/NextJS/app/components/BackendSettings.tsx
@@ -125,7 +125,7 @@ export default function BackendSettings() {
                 >
                   <Wifi className="w-6 h-6 mx-auto mb-2 text-text-primary" />
                   <div className="text-sm font-medium text-text-primary">Remote</div>
-                  <div className="text-xs text-text-tertiary mt-1">Connect via SSH</div>
+                  <div className="text-xs text-text-tertiary mt-1">Connect to remote daemon</div>
                 </button>
               </div>
             </div>
@@ -176,7 +176,7 @@ export default function BackendSettings() {
               </div>
             )}
 
-            {/* Remote Backend Settings */}
+            {/* Remote Backend Settings (SSH-WS) */}
             {config.type === 'remote' && (
               <div className="space-y-4">
                 <div>
@@ -197,101 +197,46 @@ export default function BackendSettings() {
                   />
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-text-secondary mb-2">
-                      SSH Port
-                    </label>
-                    <input
-                      type="number"
-                      value={config.remote?.sshPort || ''}
-                      onChange={(e) =>
-                        setConfig({
-                          ...config,
-                          remote: {
-                            ...config.remote!,
-                            sshPort: e.target.value ? parseInt(e.target.value) : undefined,
-                          },
-                        })
-                      }
-                      className="w-full px-3 py-2 bg-bg-elevated border border-border-subtle rounded-lg text-text-primary focus:outline-none focus:border-primary-600"
-                      placeholder="2222"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-text-secondary mb-2">
-                      MCP Server Port
-                    </label>
-                    <input
-                      type="number"
-                      value={config.remote?.mcpPort || ''}
-                      onChange={(e) =>
-                        setConfig({
-                          ...config,
-                          remote: {
-                            ...config.remote!,
-                            mcpPort: e.target.value ? parseInt(e.target.value) : undefined,
-                          },
-                        })
-                      }
-                      className="w-full px-3 py-2 bg-bg-elevated border border-border-subtle rounded-lg text-text-primary focus:outline-none focus:border-primary-600"
-                      placeholder="3001"
-                    />
-                  </div>
-                </div>
-
                 <div>
                   <label className="block text-sm font-medium text-text-secondary mb-2">
-                    Username
+                    Port
                   </label>
                   <input
-                    type="text"
-                    value={config.remote?.sshAuth.credentials.username || ''}
+                    type="number"
+                    value={config.remote?.port || ''}
                     onChange={(e) =>
                       setConfig({
                         ...config,
                         remote: {
                           ...config.remote!,
-                          sshAuth: {
-                            ...config.remote!.sshAuth,
-                            credentials: {
-                              ...config.remote!.sshAuth.credentials,
-                              username: e.target.value,
-                            },
-                          },
+                          port: e.target.value ? parseInt(e.target.value) : undefined,
                         },
                       })
                     }
                     className="w-full px-3 py-2 bg-bg-elevated border border-border-subtle rounded-lg text-text-primary focus:outline-none focus:border-primary-600"
-                    placeholder="root"
+                    placeholder="3001"
                   />
                 </div>
 
                 <div>
                   <label className="block text-sm font-medium text-text-secondary mb-2">
-                    Password
+                    Auth Token
                   </label>
                   <div className="relative">
                     <input
                       type={showPassword ? 'text' : 'password'}
-                      value={config.remote?.sshAuth.credentials.password || ''}
+                      value={config.remote?.authToken || ''}
                       onChange={(e) =>
                         setConfig({
                           ...config,
                           remote: {
                             ...config.remote!,
-                            sshAuth: {
-                              type: 'password',
-                              credentials: {
-                                ...config.remote!.sshAuth.credentials,
-                                password: e.target.value,
-                              },
-                            },
+                            authToken: e.target.value,
                           },
                         })
                       }
                       className="w-full px-3 py-2 pr-10 bg-bg-elevated border border-border-subtle rounded-lg text-text-primary focus:outline-none focus:border-primary-600"
-                      placeholder="agents"
+                      placeholder="(optional if server has no auth)"
                     />
                     <button
                       type="button"

--- a/examples/NextJS/app/lib/backend-config-types.ts
+++ b/examples/NextJS/app/lib/backend-config-types.ts
@@ -14,18 +14,13 @@ export const DEFAULT_LOCAL_CONFIG: LocalFilesystemBackendConfig = {
   isolation: 'software',
 }
 
+// Default remote config uses SSH-WS (single port, unified auth)
 export const DEFAULT_REMOTE_CONFIG: RemoteFilesystemBackendConfig = {
   host: 'localhost',
-  sshPort: 2222,
-  mcpPort: 3001,
+  port: 3001,
   rootDir: '/var/workspace',
-  sshAuth: {
-    type: 'password',
-    credentials: {
-      username: 'root',
-      password: 'agents',
-    },
-  },
+  transport: 'ssh-ws',
+  authToken: '',
 }
 
 export const COOKIE_NAME = 'backend-config'

--- a/examples/NextJS/app/lib/backend-config.ts
+++ b/examples/NextJS/app/lib/backend-config.ts
@@ -5,6 +5,36 @@ import { COOKIE_NAME, getDefaultConfig, type BackendConfig } from './backend-con
 export * from './backend-config-types'
 
 /**
+ * Validate config matches expected interface.
+ * Returns true if valid, false if should be discarded.
+ */
+function isValidConfig(config: unknown): config is BackendConfig {
+  if (!config || typeof config !== 'object') return false
+  const c = config as Record<string, unknown>
+
+  // Must have valid type
+  if (c.type !== 'local' && c.type !== 'remote') return false
+
+  // If local, must have valid local config
+  if (c.type === 'local') {
+    if (!c.local || typeof c.local !== 'object') return false
+    const local = c.local as Record<string, unknown>
+    if (typeof local.rootDir !== 'string') return false
+  }
+
+  // If remote, must have valid remote config (new format)
+  if (c.type === 'remote') {
+    if (!c.remote || typeof c.remote !== 'object') return false
+    const remote = c.remote as Record<string, unknown>
+    if (typeof remote.host !== 'string' || !remote.host) return false
+    if (typeof remote.port !== 'number') return false
+    if (typeof remote.rootDir !== 'string') return false
+  }
+
+  return true
+}
+
+/**
  * Get backend config from cookie.
  * Must be called within a request context (route handler, server component, etc.)
  */
@@ -13,7 +43,11 @@ export async function getBackendConfig(): Promise<BackendConfig> {
     const cookieStore = await cookies()
     const configCookie = cookieStore.get(COOKIE_NAME)
     if (configCookie) {
-      return JSON.parse(configCookie.value)
+      const rawConfig = JSON.parse(configCookie.value)
+      if (isValidConfig(rawConfig)) {
+        return rawConfig
+      }
+      console.warn('[getBackendConfig] Invalid config format, using defaults')
     }
   } catch (e) {
     console.warn('[getBackendConfig] Failed to read config from cookie:', e)

--- a/examples/NextJS/app/lib/backend.ts
+++ b/examples/NextJS/app/lib/backend.ts
@@ -62,12 +62,11 @@ class BackendManager {
         throw new Error('Remote backend requires host')
       }
 
-      if (!remote.sshAuth || !remote.sshAuth.credentials.username) {
-        throw new Error('Remote backend requires SSH credentials')
-      }
-
-      // RemoteFilesystemBackend will construct MCP server URL from host + mcpPort
-      this.backend = new RemoteFilesystemBackend(remote)
+      // SSH-WS transport with unified auth
+      this.backend = new RemoteFilesystemBackend({
+        ...remote,
+        transport: 'ssh-ws',
+      })
     } else {
       const local = config.local || {
         rootDir: '/tmp/workspace',

--- a/examples/NextJS/next.config.ts
+++ b/examples/NextJS/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
     "@ai-sdk/mcp",
     "ssh2",
     "cpu-features",
+    "ws",
+    "bufferutil",
+    "utf-8-validate",
   ],
 
   experimental: {
@@ -26,6 +29,9 @@ const nextConfig: NextConfig = {
       config.externals = config.externals || []
       config.externals.push({
         'ssh2': 'commonjs ssh2',
+        'ws': 'commonjs ws',
+        'bufferutil': 'commonjs bufferutil',
+        'utf-8-validate': 'commonjs utf-8-validate',
       })
     }
     return config

--- a/examples/NextJS/package.json
+++ b/examples/NextJS/package.json
@@ -29,6 +29,8 @@
     "ssh2": "^1.17.0",
     "uuid": "^9.0.1",
     "ws": "^8.18.3",
+    "bufferutil": "^4.0.9",
+    "utf-8-validate": "^6.0.5",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,5 +12,12 @@
   },
   "dependencies": {
     "diff": "^8.0.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bufferutil",
+      "utf-8-validate",
+      "cpu-features"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       ai:
         specifier: latest
         version: 6.0.78(zod@3.25.76)
+      bufferutil:
+        specifier: ^4.0.9
+        version: 4.1.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@18.3.1)
@@ -53,12 +56,15 @@ importers:
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0
+      utf-8-validate:
+        specifier: ^6.0.5
+        version: 6.0.6
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
       ws:
         specifier: ^8.18.3
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -119,7 +125,7 @@ importers:
         version: 1.17.0
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.1.5
         version: 4.3.6
@@ -1419,6 +1425,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
     engines: {node: '>=10.0.0'}
@@ -2363,6 +2373,10 @@ packages:
       sass:
         optional: true
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-gyp@10.3.1:
     resolution: {integrity: sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -2970,6 +2984,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4340,6 +4358,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   buildcheck@0.0.7:
     optional: true
 
@@ -5488,6 +5510,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-gyp-build@4.8.4: {}
+
   node-gyp@10.3.1:
     dependencies:
       env-paths: 2.2.1
@@ -6202,6 +6226,10 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   util-deprecate@1.0.2: {}
 
   uuid@9.0.1: {}
@@ -6408,7 +6436,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   yallist@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,13 +28,13 @@ importers:
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@openrouter/ai-sdk-provider':
         specifier: latest
-        version: 2.1.1(ai@6.0.73(zod@3.25.76))(zod@3.25.76)
+        version: 2.1.1(ai@6.0.78(zod@3.25.76))(zod@3.25.76)
       agent-backend:
         specifier: workspace:*
         version: link:../../typescript
       ai:
         specifier: latest
-        version: 6.0.73(zod@3.25.76)
+        version: 6.0.78(zod@3.25.76)
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@18.3.1)
@@ -117,6 +117,9 @@ importers:
       ssh2:
         specifier: ^1.16.0
         version: 1.17.0
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
       zod:
         specifier: ^4.1.5
         version: 4.3.6
@@ -136,6 +139,9 @@ importers:
       '@types/ssh2':
         specifier: ^1.15.5
         version: 1.15.5
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.0
         version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
@@ -173,8 +179,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.36':
-    resolution: {integrity: sha512-2r1Q6azvqMYxQ1hqfWZmWg4+8MajoldD/ty65XdhCaCoBfvDu7trcvxXDfTSU+3/wZ1JIDky46SWYFOHnTbsBw==}
+  '@ai-sdk/gateway@3.0.39':
+    resolution: {integrity: sha512-SeCZBAdDNbWpVUXiYgOAqis22p5MEYfrjRw0hiBa5hM+7sDGYQpMinUjkM8kbPXMkY+AhKLrHleBl+SuqpzlgA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -191,8 +197,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.14':
+    resolution: {integrity: sha512-7bzKd9lgiDeXM7O4U4nQ8iTxguAOkg8LZGD9AfDVZYjO5cKYRwBPwVjboFcVrxncRHu0tYxZtXZtiLKpG4pEng==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.7':
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.70':
@@ -1278,8 +1294,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ai@6.0.73:
-    resolution: {integrity: sha512-p2/ICXIjAM4+bIFHEkAB+l58zq+aTmxAkotsb6doNt/CEms72zt6gxv2ky1fQDwU4ecMOcmMh78VJUSEKECzlg==}
+  ai@6.0.78:
+    resolution: {integrity: sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3157,10 +3173,10 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.36(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.39(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
@@ -3192,7 +3208,18 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.14(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
   '@ai-sdk/provider@3.0.7':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -3706,9 +3733,9 @@ snapshots:
       semver: 7.7.3
     optional: true
 
-  '@openrouter/ai-sdk-provider@2.1.1(ai@6.0.73(zod@3.25.76))(zod@3.25.76)':
+  '@openrouter/ai-sdk-provider@2.1.1(ai@6.0.78(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      ai: 6.0.73(zod@3.25.76)
+      ai: 6.0.78(zod@3.25.76)
       zod: 3.25.76
 
   '@opentelemetry/api@1.9.0': {}
@@ -3945,7 +3972,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.19.7
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -4166,11 +4193,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@6.0.73(zod@3.25.76):
+  ai@6.0.78(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.36(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.39(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
-  - 'typescript'
-  - 'examples/NextJS'
+  - typescript
+  - examples/NextJS
+
+allowedBuilds: bufferutil,utf-8-validate

--- a/typescript/deploy/docker/Dockerfile.runtime
+++ b/typescript/deploy/docker/Dockerfile.runtime
@@ -1,14 +1,24 @@
 # AgentBackend Remote Backend Service
-# Provides POSIX filesystem access via SSH and MCP server for AgentBackend
+# Provides POSIX filesystem access via MCP server with SSH-over-WebSocket
+#
+# Transport modes:
+#   - SSH-WS (default): SSH over WebSocket on MCP port (single port, unified auth)
+#   - Conventional SSH (opt-in): Traditional sshd on port 22 (requires CONVENTIONAL_SSH=true)
+#
+# Build args:
+#   - AGENTBE_VERSION: Package version or "local" for local build
+#   - INCLUDE_SSHD: Set to "true" to include openssh-server for conventional SSH
 
 FROM ubuntu:22.04
+
+# Build arg to include sshd (for conventional SSH support)
+ARG INCLUDE_SSHD=true
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install base packages and SSH server
+# Install base packages
 RUN apt-get update && apt-get install -y \
-    openssh-server \
     sudo \
     curl \
     wget \
@@ -19,6 +29,11 @@ RUN apt-get update && apt-get install -y \
     bindfs \
     libfuse2 \
     && rm -rf /var/lib/apt/lists/*
+
+# Optionally install openssh-server for conventional SSH support
+RUN if [ "$INCLUDE_SSHD" = "true" ]; then \
+      apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Install Chromium and dependencies for headless browser support
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -68,42 +83,31 @@ RUN if [ "$AGENTBE_VERSION" = "local" ]; then \
 RUN mkdir -p /var/workspace
 WORKDIR /var/workspace
 
-# Set up SSH configuration
-RUN mkdir /var/run/sshd && \
-    mkdir -p /run/sshd
-
-# Generate SSH host keys
-RUN ssh-keygen -A
-
-# Configure SSH daemon for AgentBackend
-RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
-    sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config && \
-    sed -i 's/#Port 22/Port 22/' /etc/ssh/sshd_config && \
-    sed -i 's/#AddressFamily any/AddressFamily any/' /etc/ssh/sshd_config && \
-    sed -i 's/#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' /etc/ssh/sshd_config
-
-# SSH performance tuning for AgentBackend workloads
-RUN mkdir -p /etc/ssh/sshd_config.d && \
-    echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'ChallengeResponseAuthentication yes' >> /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'MaxSessions 64' >> /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'MaxStartups 10:30:100' >> /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'ClientAliveInterval 60' >> /etc/ssh/sshd_config.d/agentbe.conf && \
-    echo 'ClientAliveCountMax 3' >> /etc/ssh/sshd_config.d/agentbe.conf
-
-# SSH login fix for PAM
-RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
-
-# Set up SSH directory for root
-RUN mkdir -p /root/.ssh && \
-    chmod 700 /root/.ssh && \
-    touch /root/.ssh/authorized_keys && \
-    chmod 600 /root/.ssh/authorized_keys
-
-# Set default password (override with environment variables)
-RUN echo 'root:agents' | chpasswd
+# Set up SSH configuration (only if sshd is installed for conventional SSH)
+RUN if [ "$INCLUDE_SSHD" = "true" ]; then \
+      mkdir -p /var/run/sshd /run/sshd && \
+      ssh-keygen -A && \
+      sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+      sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+      sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config && \
+      sed -i 's/#Port 22/Port 22/' /etc/ssh/sshd_config && \
+      sed -i 's/#AddressFamily any/AddressFamily any/' /etc/ssh/sshd_config && \
+      sed -i 's/#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' /etc/ssh/sshd_config && \
+      mkdir -p /etc/ssh/sshd_config.d && \
+      echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'ChallengeResponseAuthentication yes' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'MaxSessions 64' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'MaxStartups 10:30:100' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'ClientAliveInterval 60' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      echo 'ClientAliveCountMax 3' >> /etc/ssh/sshd_config.d/agentbe.conf && \
+      sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd && \
+      mkdir -p /root/.ssh && \
+      chmod 700 /root/.ssh && \
+      touch /root/.ssh/authorized_keys && \
+      chmod 600 /root/.ssh/authorized_keys && \
+      echo 'root:agents' | chpasswd; \
+    fi
 
 # Copy startup script
 COPY typescript/deploy/docker/entrypoint.sh /entrypoint.sh
@@ -113,14 +117,18 @@ RUN chmod +x /entrypoint.sh
 RUN chmod 755 /var/workspace && \
     chown -R root:root /var/workspace
 
-# Default ports (can be overridden via SSH_PORT and MCP_PORT env vars)
+# Default ports:
+#   - 3001: MCP server (HTTP/WebSocket) + SSH-WS endpoint (ws://host:3001/ssh)
+#   - 22: Conventional SSH (only used if CONVENTIONAL_SSH=true)
 # EXPOSE is documentation only - actual ports are set by entrypoint
-EXPOSE 22 3001
+EXPOSE 3001 22
 
 # Health check for MCP server (uses default port 3001)
 # If using custom MCP_PORT, override with: --health-cmd "curl -f http://localhost:$MCP_PORT/health"
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${MCP_PORT:-3001}/health || exit 1
 
-# Start with custom entrypoint (daemon command handles everything)
+# Start agentbe-daemon
+# By default: MCP server + SSH-WS on port 3001
+# Optional: Conventional SSH on port 22 (set CONVENTIONAL_SSH=true)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/typescript/deploy/docker/docker-compose.yml
+++ b/typescript/deploy/docker/docker-compose.yml
@@ -8,10 +8,18 @@
 #
 # Or use `make dev-remote` from monorepo root (recommended for development)
 #
+# Transport modes:
+#   - SSH-WS (default): SSH over WebSocket on MCP port (single port, unified auth)
+#   - Conventional SSH (opt-in): Traditional sshd on port 22 (CONVENTIONAL_SSH=true)
+#
 # Environment variables (set in .env or export):
+#   AUTH_TOKEN     - Unified auth token for MCP and SSH-WS (recommended)
+#   MCP_PORT       - MCP + SSH-WS server port (default: 3001)
+#   DISABLE_SSH_WS - Set to "true" to disable SSH-WS endpoint
+#
+# Conventional SSH (opt-in, requires CONVENTIONAL_SSH=true):
 #   SSH_HOST_PORT  - Host port for SSH (default: 2222)
 #   SSH_PORT       - Container SSH port (default: 22)
-#   MCP_PORT       - MCP server port (default: 3001)
 #   SSH_USERS      - Comma-separated user:pass pairs (default: root:agents)
 
 services:
@@ -22,17 +30,21 @@ services:
     image: agentbe-daemon:latest
     container_name: agentbe-daemon
     ports:
-      - "${SSH_HOST_PORT:-2222}:${SSH_PORT:-22}"
+      # MCP + SSH-WS (always exposed)
       - "${MCP_PORT:-3001}:${MCP_PORT:-3001}"
+      # Conventional SSH (only used if CONVENTIONAL_SSH=true)
+      - "${SSH_HOST_PORT:-2222}:${SSH_PORT:-22}"
     volumes:
       - ./var/workspace:/var/workspace
-      # Uncomment for SSH key auth:
+      # Uncomment for SSH key auth (conventional SSH only):
       # - ./keys:/keys:ro
     env_file:
       - ../../../.env
     environment:
-      - SSH_PORT=${SSH_PORT:-22}
       - MCP_PORT=${MCP_PORT:-3001}
+      # SSH-WS is enabled by default. Uncomment to enable conventional SSH:
+      # - CONVENTIONAL_SSH=true
+      # - SSH_PORT=${SSH_PORT:-22}
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:${MCP_PORT:-3001}/health" ]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -56,6 +56,7 @@
     "hono": "^4.11.7",
     "minimatch": "^10.1.1",
     "ssh2": "^1.16.0",
+    "ws": "^8.19.0",
     "zod": "^4.1.5"
   },
   "optionalDependencies": {
@@ -75,6 +76,7 @@
     "@types/express": "^5.0.2",
     "@types/node": "^22.10.0",
     "@types/ssh2": "^1.15.5",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "eslint": "^9.16.0",

--- a/typescript/src/backends/RemoteFilesystemBackend.ts
+++ b/typescript/src/backends/RemoteFilesystemBackend.ts
@@ -17,6 +17,10 @@ import { validateWithinBoundary } from './pathValidation.js'
 import { ScopedFilesystemBackend } from './ScopedFilesystemBackend.js'
 import type { Backend, FileBasedBackend, ScopedBackend } from './types.js'
 import { BackendType } from './types.js'
+import { WebSocketSSHTransport } from './transports/WebSocketSSHTransport.js'
+
+/** Transport type for SSH operations */
+type TransportType = 'ssh-ws' | 'ssh'
 
 /** Default timeout for filesystem operations in milliseconds (120 seconds) */
 const DEFAULT_OPERATION_TIMEOUT_MS = 120_000
@@ -69,9 +73,17 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
   readonly rootDir: string
 
   private _connected = false
+  private readonly config: RemoteFilesystemBackendConfig
+
+  /** Transport type being used */
+  private readonly transportType: TransportType
+
+  /** WebSocket SSH transport (used when transport is 'ssh-ws') */
+  private wsTransport: WebSocketSSHTransport | null = null
+
+  /** Conventional SSH client (used when transport is 'ssh') */
   private sshClient: SSH2Client | null = null
   private connectionPromise: Promise<void> | null = null
-  private readonly config: RemoteFilesystemBackendConfig
 
   /** Track pending operations so we can reject them on connection loss */
   private pendingOperations = new Set<PendingOperation>()
@@ -101,12 +113,31 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
     this.config = config
     this.rootDir = config.rootDir
 
+    // Determine transport type (default to ssh-ws)
+    this.transportType = config.transport ?? 'ssh-ws'
+
+    // Validate configuration based on transport type
+    if (this.transportType === 'ssh' && !config.sshAuth) {
+      throw new BackendError(
+        'sshAuth is required when using conventional SSH transport. ' +
+        'Either provide sshAuth or use transport: "ssh-ws" with authToken.',
+        ERROR_CODES.INVALID_CONFIGURATION
+      )
+    }
+
+    if (this.transportType === 'ssh-ws' && !config.authToken) {
+      getLogger().warn(
+        'No authToken provided for ssh-ws transport. ' +
+        'Connection will only work if server has auth disabled.'
+      )
+    }
+
     // Initialize configurable timeouts with defaults
     this.operationTimeoutMs = config.operationTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS
     this.keepaliveIntervalMs = config.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS
     this.keepaliveCountMax = config.keepaliveCountMax ?? DEFAULT_KEEPALIVE_COUNT_MAX
 
-    // SSH client will be created on first connection (lazy initialization)
+    // Transport will be created on first connection (lazy initialization)
     this._connected = false
   }
 
@@ -119,7 +150,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
    */
   private getUserFromAuth(): string {
     const auth = this.config.sshAuth
-    return auth.credentials.username
+    return auth?.credentials?.username ?? 'agent'
   }
 
   /**
@@ -261,12 +292,79 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
     // Ensure SSH connection is established
     await this.ensureSSHConnection()
 
+    const cwd = options?.cwd ?? this.rootDir
+    const encoding = options?.encoding ?? 'utf8'
+    const fullCommand = this.buildFullCommand(command, cwd, options?.env)
+
+    // Use appropriate transport
+    if (this.transportType === 'ssh-ws') {
+      return this.execViaWebSocket(fullCommand, command, encoding)
+    } else {
+      return this.execViaConventionalSSH(fullCommand, command, encoding)
+    }
+  }
+
+  /**
+   * Execute command via WebSocket SSH transport
+   */
+  private async execViaWebSocket(
+    fullCommand: string,
+    originalCommand: string,
+    encoding: 'utf8' | 'buffer'
+  ): Promise<string | Buffer> {
+    if (!this.wsTransport) {
+      throw new BackendError('WebSocket transport not initialized', ERROR_CODES.EXEC_FAILED)
+    }
+
+    getLogger().debug(`[SSH-WS exec] Executing command: ${fullCommand}`)
+
+    try {
+      const result = await this.wsTransport.exec(fullCommand, {
+        timeout: this.operationTimeoutMs
+      })
+
+      if (result.code === 0) {
+        if (encoding === 'buffer') {
+          return Buffer.from(result.stdout)
+        } else {
+          let output = result.stdout.trim()
+
+          if (this.config.maxOutputLength && output.length > this.config.maxOutputLength) {
+            const truncatedLength = this.config.maxOutputLength - 50
+            output = `${output.substring(0, truncatedLength)}\n\n... [Output truncated. Full output was ${output.length} characters, showing first ${truncatedLength}]`
+          }
+
+          return output
+        }
+      } else {
+        const errorMessage = result.stderr.trim() || result.stdout.trim()
+        throw new BackendError(
+          `Command failed with exit code ${result.code}: ${errorMessage}`,
+          ERROR_CODES.EXEC_FAILED,
+          originalCommand
+        )
+      }
+    } catch (err: any) {
+      if (err instanceof BackendError) throw err
+      throw new BackendError(
+        `SSH command failed: ${err.message}`,
+        ERROR_CODES.EXEC_FAILED,
+        originalCommand
+      )
+    }
+  }
+
+  /**
+   * Execute command via conventional SSH
+   */
+  private async execViaConventionalSSH(
+    fullCommand: string,
+    originalCommand: string,
+    encoding: 'utf8' | 'buffer'
+  ): Promise<string | Buffer> {
     if (!this.sshClient) {
       throw new BackendError('SSH client not initialized', ERROR_CODES.EXEC_FAILED)
     }
-
-    const cwd = options?.cwd ?? this.rootDir
-    const encoding = options?.encoding ?? 'utf8'
 
     // Use channel limiting
     return this.withChannelLimit(() => new Promise((resolve, reject) => {
@@ -275,12 +373,10 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
         return
       }
 
-      const fullCommand = this.buildFullCommand(command, cwd, options?.env)
-
       getLogger().debug(`[SSH exec] Executing command: ${fullCommand}`)
 
       let completed = false
-      const untrack = this.trackOperation(`exec: ${command}`, reject)
+      const untrack = this.trackOperation(`exec: ${originalCommand}`, reject)
 
       const complete = () => {
         if (!completed) {
@@ -293,11 +389,11 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
       const timeout = setTimeout(() => {
         if (!completed) {
           complete()
-          getLogger().error(`[SSH exec] Command timed out after ${this.operationTimeoutMs}ms: ${command}`)
+          getLogger().error(`[SSH exec] Command timed out after ${this.operationTimeoutMs}ms: ${originalCommand}`)
           reject(new BackendError(
             `SSH command timed out after ${this.operationTimeoutMs}ms`,
             ERROR_CODES.EXEC_FAILED,
-            command
+            originalCommand
           ))
         }
       }, this.operationTimeoutMs)
@@ -309,7 +405,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
           reject(new BackendError(
             `SSH command failed: ${err.message}`,
             ERROR_CODES.EXEC_FAILED,
-            command
+            originalCommand
           ))
           return
         }
@@ -323,7 +419,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
           reject(new BackendError(
             `SSH stream error: ${streamErr.message}`,
             ERROR_CODES.EXEC_FAILED,
-            command
+            originalCommand
           ))
         })
 
@@ -355,7 +451,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
             reject(new BackendError(
               `Command failed with exit code ${code}: ${errorMessage}`,
               ERROR_CODES.EXEC_FAILED,
-              command
+              originalCommand
             ))
           }
         })
@@ -844,8 +940,11 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
 
     // Construct MCP server URL from host and port
     const mcpHost = this.config.mcpServerHostOverride || this.config.host
-    const mcpPort = this.config.mcpPort || 3001
+    const mcpPort = this.config.port ?? this.config.mcpPort ?? 3001
     const mcpServerUrl = `http://${mcpHost}:${mcpPort}`
+
+    // Use unified authToken or fallback to mcpAuth.token
+    const authToken = this.config.authToken ?? this.config.mcpAuth?.token
 
     // Create HTTP transport to remote MCP server
     const transport = new StreamableHTTPClientTransport(
@@ -853,8 +952,8 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
       {
         requestInit: {
           headers: {
-            ...(this.config.mcpAuth?.token && {
-              'Authorization': `Bearer ${this.config.mcpAuth.token}`,
+            ...(authToken && {
+              'Authorization': `Bearer ${authToken}`,
             }),
           },
         },
@@ -904,7 +1003,17 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
       this.sftpSessionPromise = null
     }
 
-    // Close SSH connection
+    // Close WebSocket transport
+    if (this.wsTransport) {
+      try {
+        await this.wsTransport.disconnect()
+      } catch (err) {
+        getLogger().debug('[SSH-WS] Error closing WebSocket transport:', err)
+      }
+      this.wsTransport = null
+    }
+
+    // Close conventional SSH connection
     if (this.sshClient) {
       try {
         this.sshClient.end()
@@ -912,9 +1021,9 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
         getLogger().debug('[SSH] Error closing SSH connection:', err)
       }
       this.sshClient = null
-      this._connected = false
     }
 
+    this._connected = false
     this.connectionPromise = null
     getLogger().debug(`RemoteFilesystemBackend destroyed for root: ${this.rootDir}`)
   }
@@ -924,31 +1033,95 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
   // =========================================================================
 
   /**
-   * Ensure SSH connection is established
+   * Ensure SSH connection is established (either ssh-ws or conventional ssh)
    */
   private async ensureSSHConnection(): Promise<void> {
-    if (this._connected && this.sshClient) {
-      return Promise.resolve()
+    if (this._connected) {
+      // Check if the appropriate transport is connected
+      if (this.transportType === 'ssh-ws' && this.wsTransport?.connected) {
+        return
+      }
+      if (this.transportType === 'ssh' && this.sshClient) {
+        return
+      }
     }
 
     if (this.connectionPromise) {
       return this.connectionPromise
     }
 
-    this.connectionPromise = this.createSSHConnection()
+    if (this.transportType === 'ssh-ws') {
+      this.connectionPromise = this.createWebSocketSSHConnection()
+    } else {
+      this.connectionPromise = this.createConventionalSSHConnection()
+    }
+
     return this.connectionPromise
   }
 
   /**
-   * Create SSH connection
+   * Create WebSocket SSH connection
    */
-  private async createSSHConnection(): Promise<void> {
+  private async createWebSocketSSHConnection(): Promise<void> {
+    const port = this.config.port ?? this.config.mcpPort ?? 3001
+
+    this.wsTransport = new WebSocketSSHTransport({
+      host: this.config.sshHostOverride || this.config.host,
+      port,
+      path: '/ssh',
+      authToken: this.config.authToken ?? this.config.mcpAuth?.token,
+      timeout: this.operationTimeoutMs,
+      keepaliveInterval: this.keepaliveIntervalMs
+    })
+
+    this.wsTransport.on('close', () => {
+      getLogger().debug('[SSH-WS] Connection closed')
+      this._connected = false
+      this.sftpSession = null
+      this.sftpSessionPromise = null
+
+      // Reject all pending operations
+      const error = new BackendError('SSH connection closed', 'CONNECTION_CLOSED')
+      for (const op of this.pendingOperations) {
+        op.reject(error)
+      }
+      this.pendingOperations.clear()
+    })
+
+    try {
+      await this.wsTransport.connect()
+      getLogger().debug('[SSH-WS] Connection established')
+      this._connected = true
+      this.connectionPromise = null
+    } catch (err: any) {
+      this._connected = false
+      this.connectionPromise = null
+      this.wsTransport = null
+      throw new BackendError(
+        `SSH-WS connection failed: ${err.message}`,
+        ERROR_CODES.EXEC_FAILED
+      )
+    }
+  }
+
+  /**
+   * Create conventional SSH connection (to sshd)
+   */
+  private async createConventionalSSHConnection(): Promise<void> {
     return new Promise((resolve, reject) => {
       const sshClient = new SSH2Client()
 
+      if (!this.config.sshAuth) {
+        reject(new BackendError(
+          'sshAuth is required for conventional SSH transport',
+          ERROR_CODES.INVALID_CONFIGURATION
+        ))
+        return
+      }
+
       const connectConfig: ConnectConfig = {
         host: this.config.sshHostOverride || this.config.host,
-        port: this.config.sshPort ?? 22,
+        port: this.config.port ?? this.config.sshPort ?? 22,
         username: this.getUserFromAuth(),
         keepaliveInterval: this.keepaliveIntervalMs,
         keepaliveCountMax: this.keepaliveCountMax,
@@ -1013,26 +1186,40 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
 
     await this.ensureSSHConnection()
 
-    this.sftpSessionPromise = new Promise((resolve, reject) => {
-      if (!this.sshClient) {
-        reject(new BackendError('SSH client not initialized', ERROR_CODES.EXEC_FAILED))
-        return
-      }
-
-      this.sshClient.sftp((err, sftp) => {
-        if (err) {
-          this.sftpSessionPromise = null
-          reject(new BackendError(
-            `Failed to create SFTP session: ${err.message}`,
-            ERROR_CODES.EXEC_FAILED
-          ))
-        } else {
-          this.sftpSession = sftp
-          this.sftpSessionPromise = null
-          resolve(sftp)
+    if (this.transportType === 'ssh-ws') {
+      // Use WebSocket transport for SFTP
+      this.sftpSessionPromise = (async () => {
+        if (!this.wsTransport) {
+          throw new BackendError('WebSocket transport not initialized', ERROR_CODES.EXEC_FAILED)
         }
+        const sftp = await this.wsTransport.getSFTP()
+        this.sftpSession = sftp
+        this.sftpSessionPromise = null
+        return sftp
+      })()
+    } else {
+      // Use conventional SSH client for SFTP
+      this.sftpSessionPromise = new Promise((resolve, reject) => {
+        if (!this.sshClient) {
+          reject(new BackendError('SSH client not initialized', ERROR_CODES.EXEC_FAILED))
+          return
+        }
+
+        this.sshClient.sftp((err, sftp) => {
+          if (err) {
+            this.sftpSessionPromise = null
+            reject(new BackendError(
+              `Failed to create SFTP session: ${err.message}`,
+              ERROR_CODES.EXEC_FAILED
+            ))
+          } else {
+            this.sftpSession = sftp
+            this.sftpSessionPromise = null
+            resolve(sftp)
+          }
+        })
       })
-    })
+    }
 
     return this.sftpSessionPromise
   }

--- a/typescript/src/backends/RemoteFilesystemBackend.ts
+++ b/typescript/src/backends/RemoteFilesystemBackend.ts
@@ -690,7 +690,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
         complete()
         if (err) {
           reject(new BackendError(
-            `Failed to read directory: ${relativePath}`,
+            `Failed to read directory: ${relativePath}: ${err.message}`,
             ERROR_CODES.LS_FAILED,
             'readdir'
           ))
@@ -736,7 +736,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
         complete()
         if (err) {
           reject(new BackendError(
-            `Failed to read directory: ${relativePath}`,
+            `Failed to read directory: ${relativePath}: ${err.message}`,
             ERROR_CODES.LS_FAILED,
             'readdirWithStats'
           ))
@@ -757,12 +757,12 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
    * Create directory
    */
   async mkdir(relativePath: string, options?: { recursive?: boolean }): Promise<void> {
-    const fullPath = this.resolvePath(relativePath)
-
     if (options?.recursive) {
-      // Use SSH command for recursive mkdir
+      // Use SSH command for recursive mkdir (exec uses full paths internally)
+      const fullPath = this.resolvePath(relativePath)
       await this.exec(`mkdir -p "${fullPath}"`)
     } else {
+      const fullPath = this.resolvePath(relativePath)
       const sftp = await this.getSFTPSession()
 
       return this.withChannelLimit(() => new Promise((resolve, reject) => {

--- a/typescript/src/backends/RemoteFilesystemBackend.ts
+++ b/typescript/src/backends/RemoteFilesystemBackend.ts
@@ -5,7 +5,7 @@ import type { Stats } from 'fs'
 import { clearTimeout, setTimeout } from 'node:timers'
 import * as path from 'path'
 import type { ConnectConfig, SFTPWrapper } from 'ssh2'
-import { Client as SSH2Client } from 'ssh2'
+import { SSH2Client, type SSH2ClientType } from '../utils/ssh2.js'
 import { ERROR_CODES } from '../constants.js'
 import { createBackendMCPTransport } from '../mcp/transport.js'
 import { isCommandSafe, isDangerous } from '../safety.js'
@@ -82,7 +82,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
   private wsTransport: WebSocketSSHTransport | null = null
 
   /** Conventional SSH client (used when transport is 'ssh') */
-  private sshClient: SSH2Client | null = null
+  private sshClient: SSH2ClientType | null = null
   private connectionPromise: Promise<void> | null = null
 
   /** Track pending operations so we can reject them on connection loss */
@@ -398,7 +398,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
         }
       }, this.operationTimeoutMs)
 
-      this.sshClient.exec(fullCommand, (err, stream) => {
+      this.sshClient.exec(fullCommand, (err: Error | undefined, stream: import('ssh2').ClientChannel) => {
         if (err) {
           if (completed) return
           complete()
@@ -1205,7 +1205,7 @@ export class RemoteFilesystemBackend implements FileBasedBackend {
           return
         }
 
-        this.sshClient.sftp((err, sftp) => {
+        this.sshClient.sftp((err: Error | undefined, sftp: SFTPWrapper) => {
           if (err) {
             this.sftpSessionPromise = null
             reject(new BackendError(

--- a/typescript/src/backends/transports/WebSocketSSHTransport.ts
+++ b/typescript/src/backends/transports/WebSocketSSHTransport.ts
@@ -11,8 +11,8 @@
  */
 
 import WebSocket from 'ws'
-import { Client as SSHClient, SFTPWrapper } from 'ssh2'
-import type { ClientChannel } from 'ssh2'
+import type { ClientChannel, SFTPWrapper } from 'ssh2'
+import { SSH2Client as SSHClient, type SSH2ClientType } from '../../utils/ssh2.js'
 import { Duplex } from 'stream'
 import { EventEmitter } from 'events'
 
@@ -45,7 +45,7 @@ export interface ExecResult {
  */
 export class WebSocketSSHTransport extends EventEmitter {
   private ws: WebSocket | null = null
-  private sshClient: SSHClient | null = null
+  private sshClient: SSH2ClientType | null = null
   private sftpSession: SFTPWrapper | null = null
   private sftpSessionPromise: Promise<SFTPWrapper> | null = null
   private _connected = false
@@ -138,7 +138,7 @@ export class WebSocketSSHTransport extends EventEmitter {
         resolve()
       })
 
-      this.sshClient.on('error', (err) => {
+      this.sshClient.on('error', (err: Error) => {
         reject(err)
       })
 
@@ -234,7 +234,7 @@ export class WebSocketSSHTransport extends EventEmitter {
         reject(new Error(`Command timed out after ${timeout}ms`))
       }, timeout)
 
-      this.sshClient!.exec(command, (err, channel: ClientChannel) => {
+      this.sshClient!.exec(command, (err: Error | undefined, channel: ClientChannel) => {
         if (err) {
           clearTimeout(timeoutId)
           reject(err)
@@ -278,7 +278,7 @@ export class WebSocketSSHTransport extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      this.sshClient!.exec(command, (err, channel: ClientChannel) => {
+      this.sshClient!.exec(command, (err: Error | undefined, channel: ClientChannel) => {
         if (err) {
           reject(err)
           return
@@ -318,7 +318,7 @@ export class WebSocketSSHTransport extends EventEmitter {
     }
 
     this.sftpSessionPromise = new Promise((resolve, reject) => {
-      this.sshClient!.sftp((err, sftp) => {
+      this.sshClient!.sftp((err: Error | undefined, sftp: SFTPWrapper) => {
         if (err) {
           this.sftpSessionPromise = null
           reject(err)

--- a/typescript/src/backends/transports/WebSocketSSHTransport.ts
+++ b/typescript/src/backends/transports/WebSocketSSHTransport.ts
@@ -1,0 +1,384 @@
+/**
+ * WebSocket SSH Transport
+ *
+ * Client-side transport that connects to an SSH-over-WebSocket server.
+ * Used by RemoteFilesystemBackend as the default transport (replacing direct sshd).
+ *
+ * Benefits:
+ * - Single port connection (same port as MCP HTTP)
+ * - Works through HTTP proxies and load balancers
+ * - Unified authentication (same token as MCP)
+ */
+
+import WebSocket from 'ws'
+import { Client as SSHClient, SFTPWrapper } from 'ssh2'
+import type { ClientChannel } from 'ssh2'
+import { Duplex } from 'stream'
+import { EventEmitter } from 'events'
+
+export interface WebSocketSSHTransportConfig {
+  /** Remote host */
+  host: string
+  /** Port for WebSocket connection (same as MCP port) */
+  port: number
+  /** WebSocket path (default: /ssh) */
+  path?: string
+  /** Bearer token for authentication */
+  authToken?: string
+  /** Connection timeout in ms (default: 30000) */
+  timeout?: number
+  /** Keep-alive interval in ms (default: 30000) */
+  keepaliveInterval?: number
+}
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  code: number
+}
+
+/**
+ * SSH transport over WebSocket
+ *
+ * Establishes an SSH connection over a WebSocket, allowing SSH operations
+ * (exec, SFTP) through a single HTTP port.
+ */
+export class WebSocketSSHTransport extends EventEmitter {
+  private ws: WebSocket | null = null
+  private sshClient: SSHClient | null = null
+  private sftpSession: SFTPWrapper | null = null
+  private sftpSessionPromise: Promise<SFTPWrapper> | null = null
+  private _connected = false
+  private readonly config: Required<Omit<WebSocketSSHTransportConfig, 'authToken'>> & { authToken?: string }
+
+  constructor(config: WebSocketSSHTransportConfig) {
+    super()
+    this.config = {
+      path: '/ssh',
+      timeout: 30000,
+      keepaliveInterval: 30000,
+      ...config
+    }
+  }
+
+  get connected(): boolean {
+    return this._connected
+  }
+
+  /**
+   * Connect to the SSH-over-WebSocket server
+   */
+  async connect(): Promise<void> {
+    if (this._connected) return
+
+    return new Promise((resolve, reject) => {
+      const protocol = this.config.port === 443 ? 'wss' : 'ws'
+      let url = `${protocol}://${this.config.host}:${this.config.port}${this.config.path}`
+
+      // Add auth token as query parameter
+      if (this.config.authToken) {
+        url += `?token=${encodeURIComponent(this.config.authToken)}`
+      }
+
+      // Connection timeout
+      const timeoutId = setTimeout(() => {
+        if (this.ws) {
+          this.ws.close()
+          this.ws = null
+        }
+        reject(new Error(`Connection timeout after ${this.config.timeout}ms`))
+      }, this.config.timeout)
+
+      this.ws = new WebSocket(url)
+
+      this.ws.on('open', () => {
+        // WebSocket connected, now establish SSH session
+        this.establishSSH()
+          .then(() => {
+            clearTimeout(timeoutId)
+            this._connected = true
+            this.emit('connect')
+            resolve()
+          })
+          .catch((err) => {
+            clearTimeout(timeoutId)
+            this.cleanup()
+            reject(err)
+          })
+      })
+
+      this.ws.on('error', (err) => {
+        clearTimeout(timeoutId)
+        this.cleanup()
+        reject(err)
+      })
+
+      this.ws.on('close', (code, reason) => {
+        this._connected = false
+        this.cleanup()
+        this.emit('close', code, reason.toString())
+      })
+    })
+  }
+
+  /**
+   * Establish SSH session over the WebSocket
+   */
+  private async establishSSH(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.ws) {
+        reject(new Error('WebSocket not connected'))
+        return
+      }
+
+      const stream = this.createStreamFromWebSocket(this.ws)
+      this.sshClient = new SSHClient()
+
+      this.sshClient.on('ready', () => {
+        resolve()
+      })
+
+      this.sshClient.on('error', (err) => {
+        reject(err)
+      })
+
+      this.sshClient.on('close', () => {
+        this._connected = false
+        this.emit('close')
+      })
+
+      // Connect SSH client over WebSocket stream
+      // Auth is via WebSocket token, so we use dummy credentials
+      this.sshClient.connect({
+        sock: stream as any,
+        username: 'agent',
+        password: 'agent',
+        readyTimeout: this.config.timeout,
+        keepaliveInterval: this.config.keepaliveInterval,
+        keepaliveCountMax: 3
+      })
+    })
+  }
+
+  /**
+   * Create a Duplex stream from a WebSocket
+   */
+  private createStreamFromWebSocket(ws: WebSocket): Duplex {
+    let destroyed = false
+
+    const stream = new Duplex({
+      read() {
+        // Data is pushed via ws.on('message')
+      },
+      write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+        if (destroyed || ws.readyState !== WebSocket.OPEN) {
+          callback(new Error('WebSocket is not open'))
+          return
+        }
+
+        ws.send(chunk, (err) => {
+          callback(err)
+        })
+      },
+      final(callback: (error?: Error | null) => void) {
+        callback()
+      },
+      destroy(err: Error | null, callback: (error?: Error | null) => void) {
+        destroyed = true
+        callback(err)
+      }
+    })
+
+    ws.on('message', (data: Buffer | ArrayBuffer | Buffer[]) => {
+      if (destroyed) return
+
+      let buffer: Buffer
+      if (Buffer.isBuffer(data)) {
+        buffer = data
+      } else if (data instanceof ArrayBuffer) {
+        buffer = Buffer.from(data)
+      } else {
+        buffer = Buffer.concat(data)
+      }
+
+      stream.push(buffer)
+    })
+
+    ws.on('close', () => {
+      if (!destroyed) {
+        stream.push(null)
+      }
+    })
+
+    ws.on('error', (err) => {
+      if (!destroyed) {
+        stream.destroy(err)
+      }
+    })
+
+    return stream
+  }
+
+  /**
+   * Execute a command over SSH
+   */
+  async exec(command: string, options?: { timeout?: number }): Promise<ExecResult> {
+    if (!this._connected || !this.sshClient) {
+      throw new Error('Not connected')
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = options?.timeout ?? 120000
+
+      const timeoutId = setTimeout(() => {
+        reject(new Error(`Command timed out after ${timeout}ms`))
+      }, timeout)
+
+      this.sshClient!.exec(command, (err, channel: ClientChannel) => {
+        if (err) {
+          clearTimeout(timeoutId)
+          reject(err)
+          return
+        }
+
+        let stdout = ''
+        let stderr = ''
+
+        channel.on('data', (data: Buffer) => {
+          stdout += data.toString()
+        })
+
+        channel.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString()
+        })
+
+        channel.on('close', (code: number) => {
+          clearTimeout(timeoutId)
+          resolve({ stdout, stderr, code: code ?? 0 })
+        })
+
+        channel.on('error', (channelErr: Error) => {
+          clearTimeout(timeoutId)
+          reject(channelErr)
+        })
+      })
+    })
+  }
+
+  /**
+   * Execute a command and stream output via callback
+   */
+  async execStream(
+    command: string,
+    onStdout: (data: Buffer) => void,
+    onStderr: (data: Buffer) => void
+  ): Promise<number> {
+    if (!this._connected || !this.sshClient) {
+      throw new Error('Not connected')
+    }
+
+    return new Promise((resolve, reject) => {
+      this.sshClient!.exec(command, (err, channel: ClientChannel) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        channel.on('data', (data: Buffer) => {
+          onStdout(data)
+        })
+
+        channel.stderr.on('data', (data: Buffer) => {
+          onStderr(data)
+        })
+
+        channel.on('close', (code: number) => {
+          resolve(code ?? 0)
+        })
+
+        channel.on('error', reject)
+      })
+    })
+  }
+
+  /**
+   * Get or create SFTP session
+   */
+  async getSFTP(): Promise<SFTPWrapper> {
+    if (this.sftpSession) {
+      return this.sftpSession
+    }
+
+    if (this.sftpSessionPromise) {
+      return this.sftpSessionPromise
+    }
+
+    if (!this._connected || !this.sshClient) {
+      throw new Error('Not connected')
+    }
+
+    this.sftpSessionPromise = new Promise((resolve, reject) => {
+      this.sshClient!.sftp((err, sftp) => {
+        if (err) {
+          this.sftpSessionPromise = null
+          reject(err)
+          return
+        }
+
+        this.sftpSession = sftp
+        this.sftpSessionPromise = null
+
+        // Handle SFTP session close
+        sftp.on('close', () => {
+          this.sftpSession = null
+        })
+
+        resolve(sftp)
+      })
+    })
+
+    return this.sftpSessionPromise
+  }
+
+  /**
+   * Disconnect from the server
+   */
+  async disconnect(): Promise<void> {
+    this.cleanup()
+  }
+
+  /**
+   * Clean up all resources
+   */
+  private cleanup(): void {
+    this._connected = false
+
+    if (this.sftpSession) {
+      try {
+        this.sftpSession.end()
+      } catch {
+        // Ignore errors during cleanup
+      }
+      this.sftpSession = null
+      this.sftpSessionPromise = null
+    }
+
+    if (this.sshClient) {
+      try {
+        this.sshClient.end()
+      } catch {
+        // Ignore errors during cleanup
+      }
+      this.sshClient = null
+    }
+
+    if (this.ws) {
+      try {
+        this.ws.close()
+      } catch {
+        // Ignore errors during cleanup
+      }
+      this.ws = null
+    }
+  }
+}

--- a/typescript/src/backends/transports/index.ts
+++ b/typescript/src/backends/transports/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SSH Transport implementations for RemoteFilesystemBackend
+ */
+
+export { WebSocketSSHTransport } from './WebSocketSSHTransport.js'
+export type { WebSocketSSHTransportConfig, ExecResult } from './WebSocketSSHTransport.js'

--- a/typescript/src/server/AgentBackendMCPServer.ts
+++ b/typescript/src/server/AgentBackendMCPServer.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Backend } from '../types.js'
+import { isFileBasedBackend } from '../typing.js'
 import { registerExecTool, registerFilesystemTools } from './tools.js'
 
 /**
@@ -38,7 +39,7 @@ import { registerExecTool, registerFilesystemTools } from './tools.js'
  * ```
  */
 export class AgentBackendMCPServer {
-  public server: McpServer & { name: string; version: string; getTools(): Record<string, any> }
+  public server: McpServer
   private backend: Backend
   private tools: Map<string, any> = new Map()
 
@@ -69,7 +70,7 @@ export class AgentBackendMCPServer {
         handler
       })
       return originalRegisterTool(name, config, handler)
-    }) as any
+    })
 
     // Add getTools method and preserve name/version
     this.server = Object.assign(baseServer, {
@@ -83,7 +84,7 @@ export class AgentBackendMCPServer {
 
     // Conditionally register exec tool based on duck typing
     // If the backend has an exec method, it supports command execution
-    if (typeof (backend as any).exec === 'function') {
+    if (isFileBasedBackend(backend)) {
       registerExecTool(this.server, async () => this.backend)
     }
   }

--- a/typescript/src/server/SFTPHandler.ts
+++ b/typescript/src/server/SFTPHandler.ts
@@ -1,0 +1,560 @@
+/**
+ * SFTP Handler
+ *
+ * Implements SFTP protocol handling for the SSH-over-WebSocket server.
+ * Provides file operations (read, write, list, stat, etc.) over SFTP.
+ */
+
+import type { SFTPWrapper, FileEntry, Attributes } from 'ssh2'
+import {
+  readdir,
+  stat,
+  lstat,
+  mkdir,
+  rmdir,
+  unlink,
+  rename,
+  realpath,
+  open as fsOpen,
+  FileHandle
+} from 'fs/promises'
+import { constants as fsConstants } from 'fs'
+import { join, resolve, dirname } from 'path'
+
+// SFTP status codes
+const SFTP_STATUS = {
+  OK: 0,
+  EOF: 1,
+  NO_SUCH_FILE: 2,
+  PERMISSION_DENIED: 3,
+  FAILURE: 4,
+  BAD_MESSAGE: 5,
+  NO_CONNECTION: 6,
+  CONNECTION_LOST: 7,
+  OP_UNSUPPORTED: 8
+} as const
+
+// SFTP open flags
+const SFTP_OPEN_FLAGS = {
+  READ: 0x00000001,
+  WRITE: 0x00000002,
+  APPEND: 0x00000004,
+  CREAT: 0x00000008,
+  TRUNC: 0x00000010,
+  EXCL: 0x00000020
+} as const
+
+// Handle types
+interface FileHandleData {
+  type: 'file'
+  path: string
+  handle: FileHandle
+  flags: number
+}
+
+interface DirHandleData {
+  type: 'dir'
+  path: string
+  entries: string[]
+  index: number
+}
+
+type HandleData = FileHandleData | DirHandleData
+
+/**
+ * Create an SFTP handler for the given SFTP stream
+ *
+ * @param sftp - The SFTP stream from ssh2
+ * @param rootDir - Root directory for all operations (paths are jailed to this)
+ */
+export function createSFTPHandler(sftp: SFTPWrapper, rootDir: string): void {
+  const handles = new Map<number, HandleData>()
+  let nextHandleId = 1
+
+  /**
+   * Resolve and validate path is within rootDir
+   */
+  function resolvePath(requestedPath: string): string {
+    // Normalize: treat absolute paths as relative to rootDir
+    const normalizedPath = requestedPath.replace(/^\/+/, '')
+    const resolved = resolve(rootDir, normalizedPath)
+
+    // Security: ensure path doesn't escape rootDir
+    if (!resolved.startsWith(rootDir)) {
+      throw new Error('Path escape attempt blocked')
+    }
+
+    return resolved
+  }
+
+  /**
+   * Allocate a handle and return its buffer representation
+   */
+  function allocHandle(data: HandleData): Buffer {
+    const id = nextHandleId++
+    handles.set(id, data)
+    const buf = Buffer.alloc(4)
+    buf.writeUInt32BE(id, 0)
+    return buf
+  }
+
+  /**
+   * Get handle data from buffer
+   */
+  function getHandle(handleBuf: Buffer): HandleData | undefined {
+    if (handleBuf.length < 4) return undefined
+    const id = handleBuf.readUInt32BE(0)
+    return handles.get(id)
+  }
+
+  /**
+   * Free a handle
+   */
+  function freeHandle(handleBuf: Buffer): void {
+    if (handleBuf.length < 4) return
+    const id = handleBuf.readUInt32BE(0)
+    handles.delete(id)
+  }
+
+  /**
+   * Convert fs.Stats to SFTP Attributes
+   */
+  function statsToAttrs(stats: import('fs').Stats): Attributes {
+    return {
+      mode: stats.mode,
+      uid: stats.uid,
+      gid: stats.gid,
+      size: stats.size,
+      atime: Math.floor(stats.atimeMs / 1000),
+      mtime: Math.floor(stats.mtimeMs / 1000)
+    }
+  }
+
+  /**
+   * Convert SFTP flags to Node.js open flags
+   */
+  function sftpFlagsToNodeFlags(sftpFlags: number): number {
+    let flags = 0
+
+    const hasRead = (sftpFlags & SFTP_OPEN_FLAGS.READ) !== 0
+    const hasWrite = (sftpFlags & SFTP_OPEN_FLAGS.WRITE) !== 0
+
+    if (hasRead && hasWrite) {
+      flags = fsConstants.O_RDWR
+    } else if (hasWrite) {
+      flags = fsConstants.O_WRONLY
+    } else {
+      flags = fsConstants.O_RDONLY
+    }
+
+    if (sftpFlags & SFTP_OPEN_FLAGS.CREAT) flags |= fsConstants.O_CREAT
+    if (sftpFlags & SFTP_OPEN_FLAGS.TRUNC) flags |= fsConstants.O_TRUNC
+    if (sftpFlags & SFTP_OPEN_FLAGS.EXCL) flags |= fsConstants.O_EXCL
+    if (sftpFlags & SFTP_OPEN_FLAGS.APPEND) flags |= fsConstants.O_APPEND
+
+    return flags
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // File Operations
+  // ─────────────────────────────────────────────────────────────────
+
+  sftp.on('OPEN', async (reqid, filename, flags, attrs) => {
+    try {
+      const path = resolvePath(filename)
+      const nodeFlags = sftpFlagsToNodeFlags(flags)
+      const mode = attrs.mode ?? 0o644
+
+      // Ensure parent directory exists for write operations
+      if (flags & (SFTP_OPEN_FLAGS.WRITE | SFTP_OPEN_FLAGS.CREAT)) {
+        const parentDir = dirname(path)
+        await mkdir(parentDir, { recursive: true }).catch(() => {})
+      }
+
+      const handle = await fsOpen(path, nodeFlags, mode)
+
+      const handleBuf = allocHandle({
+        type: 'file',
+        path,
+        handle,
+        flags
+      })
+
+      sftp.handle(reqid, handleBuf)
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : err.code === 'EACCES'
+          ? SFTP_STATUS.PERMISSION_DENIED
+          : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('READ', async (reqid, handleBuf, offset, length) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (!handleData || handleData.type !== 'file') {
+        sftp.status(reqid, SFTP_STATUS.FAILURE, 'Invalid handle')
+        return
+      }
+
+      const buffer = Buffer.alloc(length)
+      const { bytesRead } = await handleData.handle.read(buffer, 0, length, offset)
+
+      if (bytesRead === 0) {
+        sftp.status(reqid, SFTP_STATUS.EOF)
+      } else {
+        sftp.data(reqid, buffer.subarray(0, bytesRead))
+      }
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  sftp.on('WRITE', async (reqid, handleBuf, offset, data) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (!handleData || handleData.type !== 'file') {
+        sftp.status(reqid, SFTP_STATUS.FAILURE, 'Invalid handle')
+        return
+      }
+
+      await handleData.handle.write(data, 0, data.length, offset)
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  sftp.on('CLOSE', async (reqid, handleBuf) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (handleData?.type === 'file') {
+        await handleData.handle.close()
+      }
+      freeHandle(handleBuf)
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  sftp.on('FSTAT', async (reqid, handleBuf) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (!handleData || handleData.type !== 'file') {
+        sftp.status(reqid, SFTP_STATUS.FAILURE, 'Invalid handle')
+        return
+      }
+
+      const stats = await handleData.handle.stat()
+      sftp.attrs(reqid, statsToAttrs(stats))
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  // ─────────────────────────────────────────────────────────────────
+  // Directory Operations
+  // ─────────────────────────────────────────────────────────────────
+
+  sftp.on('OPENDIR', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+      const entries = await readdir(resolved)
+
+      const handleBuf = allocHandle({
+        type: 'dir',
+        path: resolved,
+        entries,
+        index: 0
+      })
+
+      sftp.handle(reqid, handleBuf)
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('READDIR', async (reqid, handleBuf) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (!handleData || handleData.type !== 'dir') {
+        sftp.status(reqid, SFTP_STATUS.FAILURE, 'Invalid handle')
+        return
+      }
+
+      const { entries, index, path } = handleData
+      if (index >= entries.length) {
+        sftp.status(reqid, SFTP_STATUS.EOF)
+        return
+      }
+
+      // Return up to 50 entries at a time
+      const batchSize = 50
+      const batch = entries.slice(index, index + batchSize)
+      handleData.index = index + batch.length
+
+      const names: FileEntry[] = await Promise.all(
+        batch.map(async (name) => {
+          const fullPath = join(path, name)
+          try {
+            const stats = await lstat(fullPath)
+            return {
+              filename: name,
+              longname: formatLongname(name, stats),
+              attrs: statsToAttrs(stats) as Attributes
+            }
+          } catch {
+            // If stat fails, return minimal info
+            return {
+              filename: name,
+              longname: `?????????? ? ? ? ? ? ${name}`,
+              attrs: {} as Attributes
+            }
+          }
+        })
+      )
+
+      sftp.name(reqid, names)
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  // ─────────────────────────────────────────────────────────────────
+  // Path Operations
+  // ─────────────────────────────────────────────────────────────────
+
+  sftp.on('STAT', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+      const stats = await stat(resolved)
+      sftp.attrs(reqid, statsToAttrs(stats))
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('LSTAT', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+      const stats = await lstat(resolved)
+      sftp.attrs(reqid, statsToAttrs(stats))
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('REALPATH', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+
+      // Return path relative to rootDir (as seen by client)
+      let real: string
+      try {
+        real = await realpath(resolved)
+      } catch {
+        // Path doesn't exist yet, return normalized path
+        real = resolved
+      }
+
+      // Convert back to client-visible path
+      const clientPath = real.startsWith(rootDir)
+        ? '/' + real.slice(rootDir.length).replace(/^\/+/, '')
+        : '/'
+
+      sftp.name(reqid, [{
+        filename: clientPath || '/',
+        longname: clientPath || '/',
+        attrs: {} as Attributes
+      }])
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  sftp.on('MKDIR', async (reqid, path, attrs) => {
+    try {
+      const resolved = resolvePath(path)
+      await mkdir(resolved, { mode: attrs.mode ?? 0o755 })
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      const status = err.code === 'EEXIST'
+        ? SFTP_STATUS.FAILURE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('RMDIR', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+      await rmdir(resolved)
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('REMOVE', async (reqid, path) => {
+    try {
+      const resolved = resolvePath(path)
+      await unlink(resolved)
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('RENAME', async (reqid, oldPath, newPath) => {
+    try {
+      const resolvedOld = resolvePath(oldPath)
+      const resolvedNew = resolvePath(newPath)
+
+      // Ensure parent directory exists
+      await mkdir(dirname(resolvedNew), { recursive: true }).catch(() => {})
+
+      await rename(resolvedOld, resolvedNew)
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      const status = err.code === 'ENOENT'
+        ? SFTP_STATUS.NO_SUCH_FILE
+        : SFTP_STATUS.FAILURE
+      sftp.status(reqid, status, err.message)
+    }
+  })
+
+  sftp.on('SETSTAT', async (reqid, path, attrs) => {
+    // Set file attributes - we support a subset
+    try {
+      const resolved = resolvePath(path)
+
+      // chmod if mode is specified
+      if (attrs.mode !== undefined) {
+        const { chmod } = await import('fs/promises')
+        await chmod(resolved, attrs.mode)
+      }
+
+      // chown if uid/gid specified (requires root)
+      if (attrs.uid !== undefined || attrs.gid !== undefined) {
+        const { chown } = await import('fs/promises')
+        const currentStats = await stat(resolved)
+        await chown(
+          resolved,
+          attrs.uid ?? currentStats.uid,
+          attrs.gid ?? currentStats.gid
+        ).catch(() => {}) // Ignore permission errors
+      }
+
+      // utimes if atime/mtime specified
+      if (attrs.atime !== undefined || attrs.mtime !== undefined) {
+        const { utimes } = await import('fs/promises')
+        const currentStats = await stat(resolved)
+        await utimes(
+          resolved,
+          attrs.atime ?? Math.floor(currentStats.atimeMs / 1000),
+          attrs.mtime ?? Math.floor(currentStats.mtimeMs / 1000)
+        ).catch(() => {})
+      }
+
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+
+  sftp.on('FSETSTAT', async (reqid, handleBuf, attrs) => {
+    try {
+      const handleData = getHandle(handleBuf)
+      if (!handleData || handleData.type !== 'file') {
+        sftp.status(reqid, SFTP_STATUS.FAILURE, 'Invalid handle')
+        return
+      }
+
+      // chmod if mode is specified
+      if (attrs.mode !== undefined) {
+        await handleData.handle.chmod(attrs.mode)
+      }
+
+      // chown if uid/gid specified
+      if (attrs.uid !== undefined || attrs.gid !== undefined) {
+        const currentStats = await handleData.handle.stat()
+        await handleData.handle.chown(
+          attrs.uid ?? currentStats.uid,
+          attrs.gid ?? currentStats.gid
+        ).catch(() => {})
+      }
+
+      sftp.status(reqid, SFTP_STATUS.OK)
+    } catch (err: any) {
+      sftp.status(reqid, SFTP_STATUS.FAILURE, err.message)
+    }
+  })
+}
+
+/**
+ * Format a long name for directory listing (ls -l style)
+ */
+function formatLongname(name: string, stats: import('fs').Stats): string {
+  const typeChar = stats.isDirectory() ? 'd' : stats.isSymbolicLink() ? 'l' : '-'
+  const perms = formatPermissions(stats.mode)
+  const nlink = stats.nlink.toString().padStart(3)
+  const uid = stats.uid.toString().padStart(5)
+  const gid = stats.gid.toString().padStart(5)
+  const size = stats.size.toString().padStart(10)
+  const date = formatDate(stats.mtime)
+
+  return `${typeChar}${perms} ${nlink} ${uid} ${gid} ${size} ${date} ${name}`
+}
+
+/**
+ * Format file permissions as rwxrwxrwx string
+ */
+function formatPermissions(mode: number): string {
+  const chars = 'rwxrwxrwx'
+  let result = ''
+  for (let i = 0; i < 9; i++) {
+    result += (mode & (1 << (8 - i))) ? chars[i] : '-'
+  }
+  return result
+}
+
+/**
+ * Format date for ls output
+ */
+function formatDate(date: Date): string {
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const month = months[date.getMonth()]
+  const day = date.getDate().toString().padStart(2)
+
+  const now = new Date()
+  const sixMonthsAgo = new Date(now.getTime() - 180 * 24 * 60 * 60 * 1000)
+
+  if (date > sixMonthsAgo) {
+    // Recent: show time
+    const hours = date.getHours().toString().padStart(2, '0')
+    const mins = date.getMinutes().toString().padStart(2, '0')
+    return `${month} ${day} ${hours}:${mins}`
+  } else {
+    // Old: show year
+    return `${month} ${day}  ${date.getFullYear()}`
+  }
+}

--- a/typescript/src/server/WebSocketSSHServer.ts
+++ b/typescript/src/server/WebSocketSSHServer.ts
@@ -13,8 +13,8 @@
 
 import type { Server as HTTPServer, IncomingMessage } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
-import { Server as SSH2Server, Connection } from 'ssh2'
-import type { AuthContext, Session, ServerChannel, ExecInfo, PseudoTtyInfo } from 'ssh2'
+import type { AuthContext, Session, ServerChannel, ExecInfo, PseudoTtyInfo, Connection } from 'ssh2'
+import { SSH2Server } from '../utils/ssh2.js'
 import { Duplex } from 'stream'
 import { spawn } from 'child_process'
 import { generateKeyPairSync } from 'crypto'

--- a/typescript/src/server/WebSocketSSHServer.ts
+++ b/typescript/src/server/WebSocketSSHServer.ts
@@ -1,0 +1,464 @@
+/**
+ * WebSocket SSH Server
+ *
+ * Provides SSH protocol over WebSocket connections. This enables single-port
+ * deployments where both MCP (HTTP) and SSH (WebSocket) share the same port.
+ *
+ * Benefits:
+ * - Single port for all daemon functionality
+ * - Works through HTTP load balancers and proxies
+ * - Unified authentication (same token for MCP and SSH)
+ * - Simpler firewall and NetworkPolicy configuration
+ */
+
+import type { Server as HTTPServer, IncomingMessage } from 'http'
+import { WebSocketServer, WebSocket } from 'ws'
+import { Server as SSH2Server, Connection } from 'ssh2'
+import type { AuthContext, Session, ServerChannel, ExecInfo, PseudoTtyInfo } from 'ssh2'
+import { Duplex } from 'stream'
+import { spawn } from 'child_process'
+import { generateKeyPairSync } from 'crypto'
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { createSFTPHandler } from './SFTPHandler.js'
+
+export interface WebSocketSSHServerOptions {
+  /** Root directory for all operations */
+  rootDir: string
+  /** Optional bearer token for authentication (reuses MCP auth) */
+  authToken?: string
+  /** Path to SSH host key file. Auto-generated if not found. */
+  hostKeyPath?: string
+  /** Shell to use for exec/shell sessions */
+  shell?: 'bash' | 'sh' | 'auto'
+}
+
+export interface WebSocketSSHServerInstance {
+  /** The underlying WebSocket server */
+  wss: WebSocketServer
+  /** Close the server and all connections */
+  close: () => Promise<void>
+}
+
+/**
+ * Creates a WebSocket server that speaks SSH protocol.
+ * Clients connect via WebSocket, then use standard SSH client libraries.
+ *
+ * @param httpServer - The HTTP server to attach WebSocket upgrade handling to
+ * @param options - Configuration options
+ * @returns WebSocket SSH server instance
+ */
+export function createWebSocketSSHServer(
+  httpServer: HTTPServer,
+  options: WebSocketSSHServerOptions
+): WebSocketSSHServerInstance {
+  const hostKey = loadOrGenerateHostKey(options.hostKeyPath)
+  const shell = resolveShell(options.shell)
+
+  const wss = new WebSocketServer({
+    server: httpServer,
+    path: '/ssh'
+  })
+
+  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+    // Authenticate via query param or Authorization header
+    if (!authenticateConnection(req, options.authToken)) {
+      ws.close(4001, 'Unauthorized')
+      return
+    }
+
+    handleSSHOverWebSocket(ws, {
+      hostKey,
+      rootDir: options.rootDir,
+      shell
+    })
+  })
+
+  wss.on('error', (err) => {
+    console.error('[SSH-WS] WebSocket server error:', err.message)
+  })
+
+  return {
+    wss,
+    close: async () => {
+      return new Promise((resolve) => {
+        // Close all active connections
+        for (const client of wss.clients) {
+          client.close(1000, 'Server shutting down')
+        }
+        wss.close(() => resolve())
+      })
+    }
+  }
+}
+
+/**
+ * Validate authentication token from WebSocket connection
+ */
+function authenticateConnection(req: IncomingMessage, expectedToken?: string): boolean {
+  if (!expectedToken) return true // No auth configured
+
+  // Check query parameter: /ssh?token=xxx
+  const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`)
+  const queryToken = url.searchParams.get('token')
+  if (queryToken === expectedToken) return true
+
+  // Check Authorization header: Bearer xxx
+  const authHeader = req.headers['authorization']
+  if (authHeader?.startsWith('Bearer ')) {
+    const headerToken = authHeader.slice(7)
+    if (headerToken === expectedToken) return true
+  }
+
+  return false
+}
+
+interface SSHSessionContext {
+  hostKey: Buffer
+  rootDir: string
+  shell: string
+}
+
+/**
+ * Handle an SSH connection over a WebSocket
+ */
+function handleSSHOverWebSocket(ws: WebSocket, ctx: SSHSessionContext): void {
+  // Create a bidirectional stream from the WebSocket
+  const wsStream = createDuplexFromWebSocket(ws)
+
+  // Create SSH server for this connection
+  const sshServer = new SSH2Server({ hostKeys: [ctx.hostKey] })
+
+  sshServer.on('connection', (client: Connection) => {
+    let isAuthenticated = false
+
+    client.on('authentication', (authCtx: AuthContext) => {
+      // We've already authenticated via WebSocket token
+      // Accept any SSH auth method (password, publickey, none)
+      isAuthenticated = true
+      authCtx.accept()
+    })
+
+    client.on('ready', () => {
+      client.on('session', (accept, reject) => {
+        if (!isAuthenticated) {
+          reject?.()
+          return
+        }
+
+        const session = accept()
+        handleSession(session, ctx)
+      })
+    })
+
+    client.on('error', (err) => {
+      console.error('[SSH-WS] Client error:', err.message)
+    })
+
+    client.on('end', () => {
+      // Client disconnected
+    })
+  })
+
+  sshServer.on('error', (err: Error) => {
+    console.error('[SSH-WS] SSH server error:', err.message)
+  })
+
+  // Pipe WebSocket ↔ SSH server using injectSocket
+  // The ssh2 Server's injectSocket method accepts a Duplex stream
+  // that it will use for the SSH protocol communication
+  try {
+    ;(sshServer as any).injectSocket(wsStream)
+  } catch (err) {
+    console.error('[SSH-WS] Failed to inject socket:', err)
+    ws.close(1011, 'SSH initialization failed')
+  }
+}
+
+/**
+ * Handle an SSH session (shell, exec, subsystem requests)
+ */
+function handleSession(session: Session, ctx: SSHSessionContext): void {
+  let ptyInfo: PseudoTtyInfo | null = null
+
+  session.on('pty', (accept, _reject, info: PseudoTtyInfo) => {
+    ptyInfo = info
+    accept?.()
+  })
+
+  session.on('shell', (accept, _reject) => {
+    const channel = accept?.()
+    if (channel) {
+      spawnShell(channel, ctx, ptyInfo)
+    }
+  })
+
+  session.on('exec', (accept, _reject, info: ExecInfo) => {
+    const channel = accept?.()
+    if (channel) {
+      executeCommand(info.command, channel, ctx)
+    }
+  })
+
+  session.on('sftp', (accept, _reject) => {
+    const sftpStream = accept?.()
+    if (sftpStream) {
+      createSFTPHandler(sftpStream, ctx.rootDir)
+    }
+  })
+
+  session.on('window-change', (accept, _reject, _info) => {
+    // Window resize - would need to track active PTY to resize
+    accept?.()
+  })
+}
+
+/**
+ * Execute a command and stream output to the SSH channel
+ */
+function executeCommand(
+  command: string,
+  channel: ServerChannel,
+  ctx: SSHSessionContext
+): void {
+  const proc = spawn(ctx.shell, ['-c', command], {
+    cwd: ctx.rootDir,
+    env: {
+      ...process.env,
+      HOME: ctx.rootDir,
+      PWD: ctx.rootDir,
+      TERM: 'xterm-256color'
+    },
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+
+  // Stream output to channel
+  proc.stdout.on('data', (data: Buffer) => {
+    channel.write(data)
+  })
+
+  proc.stderr.on('data', (data: Buffer) => {
+    channel.stderr.write(data)
+  })
+
+  // Stream input from channel
+  channel.on('data', (data: Buffer) => {
+    if (proc.stdin.writable) {
+      proc.stdin.write(data)
+    }
+  })
+
+  channel.on('end', () => {
+    proc.stdin.end()
+  })
+
+  proc.on('close', (code, signal) => {
+    const exitCode = code ?? (signal ? 128 : 0)
+    channel.exit(exitCode)
+    channel.end()
+  })
+
+  proc.on('error', (err) => {
+    channel.stderr.write(`Error: ${err.message}\n`)
+    channel.exit(1)
+    channel.end()
+  })
+}
+
+/**
+ * Spawn an interactive shell session
+ */
+function spawnShell(
+  channel: ServerChannel,
+  ctx: SSHSessionContext,
+  ptyInfo: PseudoTtyInfo | null
+): void {
+  // For interactive shells, we ideally want a PTY
+  // Try to use node-pty if available, otherwise fall back to regular spawn
+  trySpawnWithPty(channel, ctx, ptyInfo).catch(() => {
+    // Fallback: spawn shell without PTY
+    executeCommand(ctx.shell, channel, ctx)
+  })
+}
+
+/**
+ * Try to spawn a shell with PTY support using node-pty
+ */
+async function trySpawnWithPty(
+  channel: ServerChannel,
+  ctx: SSHSessionContext,
+  ptyInfo: PseudoTtyInfo | null
+): Promise<void> {
+  // Dynamically require node-pty (optional dependency)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports
+  let nodePty: any
+  try {
+    // node-pty is optional - only required for interactive shell with PTY
+    // Use dynamic require to avoid TypeScript module resolution
+    const moduleName = 'node-pty'
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    nodePty = require(moduleName)
+  } catch {
+    throw new Error('node-pty not available')
+  }
+
+  // Extract term type safely - ssh2's PseudoTtyInfo has term as optional property
+  const ptyInfoAny = ptyInfo as unknown as { term?: string; cols?: number; rows?: number } | null
+  const termType = ptyInfoAny?.term ?? 'xterm-256color'
+
+  const pty = nodePty.spawn(ctx.shell, [], {
+    name: termType,
+    cols: ptyInfoAny?.cols ?? 80,
+    rows: ptyInfoAny?.rows ?? 24,
+    cwd: ctx.rootDir,
+    env: {
+      ...process.env,
+      HOME: ctx.rootDir,
+      PWD: ctx.rootDir,
+      TERM: termType
+    } as Record<string, string>
+  })
+
+  // PTY output -> SSH channel
+  pty.onData((data: string) => {
+    channel.write(data)
+  })
+
+  // SSH channel -> PTY input
+  channel.on('data', (data: Buffer) => {
+    pty.write(data.toString())
+  })
+
+  channel.on('end', () => {
+    pty.kill()
+  })
+
+  pty.onExit(({ exitCode }: { exitCode: number }) => {
+    channel.exit(exitCode)
+    channel.end()
+  })
+}
+
+/**
+ * Create a Duplex stream from a WebSocket connection
+ */
+function createDuplexFromWebSocket(ws: WebSocket): Duplex {
+  let destroyed = false
+
+  const stream = new Duplex({
+    read() {
+      // Data is pushed via ws.on('message')
+    },
+    write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+      if (destroyed || ws.readyState !== WebSocket.OPEN) {
+        callback(new Error('WebSocket is not open'))
+        return
+      }
+
+      ws.send(chunk, (err) => {
+        callback(err)
+      })
+    },
+    final(callback: (error?: Error | null) => void) {
+      ws.close(1000, 'Stream closed')
+      callback()
+    },
+    destroy(err: Error | null, callback: (error?: Error | null) => void) {
+      destroyed = true
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.close(1011, err?.message || 'Stream destroyed')
+      }
+      callback(err)
+    }
+  })
+
+  // WebSocket messages -> Duplex stream
+  ws.on('message', (data: Buffer | ArrayBuffer | Buffer[]) => {
+    if (destroyed) return
+
+    let buffer: Buffer
+    if (Buffer.isBuffer(data)) {
+      buffer = data
+    } else if (data instanceof ArrayBuffer) {
+      buffer = Buffer.from(data)
+    } else {
+      buffer = Buffer.concat(data)
+    }
+
+    stream.push(buffer)
+  })
+
+  ws.on('close', () => {
+    if (!destroyed) {
+      stream.push(null) // Signal EOF
+    }
+  })
+
+  ws.on('error', (err) => {
+    if (!destroyed) {
+      stream.destroy(err)
+    }
+  })
+
+  return stream
+}
+
+/**
+ * Load SSH host key from file, or generate a new one
+ */
+function loadOrGenerateHostKey(hostKeyPath?: string): Buffer {
+  const defaultPath = '/var/lib/agentbe/ssh_host_ed25519_key'
+  const keyPath = hostKeyPath || defaultPath
+
+  // Try to load existing key
+  if (existsSync(keyPath)) {
+    try {
+      return readFileSync(keyPath)
+    } catch (err) {
+      console.error(`[SSH-WS] Failed to read host key from ${keyPath}:`, err)
+    }
+  }
+
+  // Generate new host key
+  console.error(`[SSH-WS] Generating SSH host key at ${keyPath}`)
+
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+    publicKeyEncoding: { type: 'pkcs1', format: 'pem' }
+  })
+
+  // Ensure directory exists
+  const dir = dirname(keyPath)
+  if (dir && !existsSync(dir)) {
+    try {
+      mkdirSync(dir, { recursive: true })
+    } catch {
+      // Directory creation failed, key will be ephemeral
+      console.error(`[SSH-WS] Could not create directory ${dir}, using ephemeral key`)
+      return Buffer.from(privateKey)
+    }
+  }
+
+  // Save key to file
+  try {
+    writeFileSync(keyPath, privateKey, { mode: 0o600 })
+    console.error(`[SSH-WS] Host key saved to ${keyPath}`)
+  } catch {
+    console.error(`[SSH-WS] Could not save host key to ${keyPath}, using ephemeral key`)
+  }
+
+  return Buffer.from(privateKey)
+}
+
+/**
+ * Resolve which shell to use
+ */
+function resolveShell(shell?: 'bash' | 'sh' | 'auto'): string {
+  if (shell === 'bash') return '/bin/bash'
+  if (shell === 'sh') return '/bin/sh'
+
+  // Auto-detect: prefer bash if available
+  if (existsSync('/bin/bash')) return '/bin/bash'
+  return '/bin/sh'
+}

--- a/typescript/src/server/index.ts
+++ b/typescript/src/server/index.ts
@@ -11,3 +11,6 @@
 
 export { AgentBackendMCPServer } from './AgentBackendMCPServer.js'
 export { registerFilesystemTools, registerExecTool, DEFAULT_EXCLUDE_PATTERNS } from './tools.js'
+export { createWebSocketSSHServer } from './WebSocketSSHServer.js'
+export type { WebSocketSSHServerOptions, WebSocketSSHServerInstance } from './WebSocketSSHServer.js'
+export { createSFTPHandler } from './SFTPHandler.js'

--- a/typescript/src/utils/ssh2.ts
+++ b/typescript/src/utils/ssh2.ts
@@ -1,0 +1,21 @@
+/**
+ * SSH2 module wrapper for ESM/CJS interop
+ *
+ * This wrapper enables proper mocking in tests while
+ * maintaining runtime compatibility with ssh2's CJS exports.
+ */
+
+import { createRequire } from 'module'
+import type { Client as SSH2ClientType, Server as SSH2ServerType } from 'ssh2'
+
+// Re-export types for use in type annotations
+export type { Client as SSH2ClientType, Server as SSH2ServerType } from 'ssh2'
+
+const require = createRequire(import.meta.url)
+const ssh2 = require('ssh2') as {
+  Client: typeof SSH2ClientType
+  Server: typeof SSH2ServerType
+}
+
+export const SSH2Client = ssh2.Client
+export const SSH2Server = ssh2.Server

--- a/typescript/tests/unit/backends/RemoteFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/RemoteFilesystemBackend.test.ts
@@ -12,6 +12,11 @@ vi.mock('ssh2', () => ({
 // Test constants
 const TEST_ROOT_DIR = '/remote/workspace'
 
+// Base config for all tests - uses conventional SSH transport for mocking
+const BASE_SSH_CONFIG = {
+  transport: 'ssh' as const,  // Use conventional SSH for unit tests (mocked)
+}
+
 /**
  * Build the expected full command string that RemoteFilesystemBackend.exec() generates.
  * This mirrors the logic in buildFullCommand() for test assertions.
@@ -124,6 +129,8 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -156,6 +163,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const passwordBackend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -171,6 +179,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const keyBackend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -189,6 +198,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const defaultPortBackend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -204,6 +214,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const customPortBackend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshPort: 2222,
@@ -220,6 +231,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -240,6 +252,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -255,6 +268,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: '/tmp',
         host: 'example.com',
         sshAuth: {
@@ -270,6 +284,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -290,6 +305,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -310,6 +326,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -331,6 +348,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -355,6 +373,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -371,6 +390,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -386,6 +406,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -404,6 +425,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -421,6 +443,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         preventDangerous: true,
@@ -440,6 +463,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         preventDangerous: false,
@@ -486,6 +510,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -512,6 +537,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -540,6 +566,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -580,6 +607,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -611,6 +639,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -638,6 +667,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -664,6 +694,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -683,6 +714,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -709,6 +741,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -739,6 +772,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -755,6 +789,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -772,6 +807,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -790,6 +826,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -805,6 +842,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -825,6 +863,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -845,6 +884,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => createMockSSHClient() as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {
@@ -875,6 +915,7 @@ describe('RemoteFilesystemBackend (Unit Tests)', () => {
       vi.mocked(Client).mockImplementation(() => mockClient as any)
 
       const backend = new RemoteFilesystemBackend({
+        ...BASE_SSH_CONFIG,
         rootDir: TEST_ROOT_DIR,
         host: 'example.com',
         sshAuth: {

--- a/typescript/tests/unit/backends/RemoteFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/RemoteFilesystemBackend.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { RemoteFilesystemBackend } from '../../../src/backends/RemoteFilesystemBackend.js'
-import { Client } from 'ssh2'
 import { DangerousOperationError } from '../../../src/types.js'
 import { EventEmitter } from 'events'
 
-// Mock SSH2
-vi.mock('ssh2', () => ({
-  Client: vi.fn()
+// Mock our SSH2 wrapper
+vi.mock('../../../src/utils/ssh2.js', () => ({
+  SSH2Client: vi.fn()
 }))
+
+import { RemoteFilesystemBackend } from '../../../src/backends/RemoteFilesystemBackend.js'
+import { SSH2Client as Client } from '../../../src/utils/ssh2.js'
 
 // Test constants
 const TEST_ROOT_DIR = '/remote/workspace'

--- a/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
@@ -89,6 +89,20 @@ describe('ScopedFilesystemBackend (Unit Tests)', () => {
       expect(mockParent.read).toHaveBeenCalledWith('users/user1/file.txt', undefined)
     })
 
+    it('should handle absolute paths matching full rootDir', async () => {
+      // Full absolute path /tmp/workspace/users/user1/file.txt should work
+      await scoped.read('/tmp/workspace/users/user1/file.txt')
+
+      expect(mockParent.read).toHaveBeenCalledWith('users/user1/file.txt', undefined)
+    })
+
+    it('should handle absolute path equal to rootDir', async () => {
+      // Path equal to rootDir should resolve to scope root
+      await scoped.readdir('/tmp/workspace/users/user1')
+
+      expect(mockParent.readdir).toHaveBeenCalledWith('users/user1')
+    })
+
     it('should block parent directory escapes', async () => {
       await expect(scoped.read('../../etc/passwd'))
         .rejects.toThrow(PathEscapeError)

--- a/typescript/tests/unit/backends/pathValidation.test.ts
+++ b/typescript/tests/unit/backends/pathValidation.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { validateWithinBoundary, validateAbsoluteWithinRoot } from '../../../src/backends/pathValidation.js'
+import { PathEscapeError } from '../../../src/types.js'
+
+describe('validateWithinBoundary', () => {
+  describe('relative paths', () => {
+    it('should resolve simple relative path', () => {
+      const result = validateWithinBoundary('file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should resolve nested relative path', () => {
+      const result = validateWithinBoundary('subdir/file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/subdir/file.txt')
+    })
+
+    it('should resolve current directory reference', () => {
+      const result = validateWithinBoundary('.', '/var/workspace', path)
+      expect(result).toBe('/var/workspace')
+    })
+
+    it('should resolve ./file reference', () => {
+      const result = validateWithinBoundary('./file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should normalize path with internal ..', () => {
+      const result = validateWithinBoundary('a/b/../c', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/a/c')
+    })
+
+    it('should allow .. that stays within boundary', () => {
+      const result = validateWithinBoundary('a/b/../../c', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/c')
+    })
+  })
+
+  describe('absolute paths matching boundary', () => {
+    it('should use absolute path directly when it matches boundary exactly', () => {
+      const result = validateWithinBoundary('/var/workspace', '/var/workspace', path)
+      expect(result).toBe('/var/workspace')
+    })
+
+    it('should use absolute path directly when it starts with boundary', () => {
+      const result = validateWithinBoundary('/var/workspace/file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should use absolute path directly for nested paths within boundary', () => {
+      const result = validateWithinBoundary('/var/workspace/a/b/c.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/a/b/c.txt')
+    })
+
+    it('should normalize absolute paths within boundary', () => {
+      const result = validateWithinBoundary('/var/workspace/a/../b', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/b')
+    })
+  })
+
+  describe('absolute paths not matching boundary (treated as relative)', () => {
+    it('should treat /file.txt as relative to boundary', () => {
+      const result = validateWithinBoundary('/file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should treat /other/path as relative to boundary', () => {
+      const result = validateWithinBoundary('/other/path/file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/other/path/file.txt')
+    })
+
+    it('should handle paths that look similar but do not match boundary', () => {
+      // /var/workspace2 should NOT be treated as within /var/workspace
+      const result = validateWithinBoundary('/var/workspace2/file.txt', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/var/workspace2/file.txt')
+    })
+  })
+
+  describe('escape attempts (should throw)', () => {
+    it('should reject simple parent escape', () => {
+      expect(() => validateWithinBoundary('../etc/passwd', '/var/workspace', path))
+        .toThrow(PathEscapeError)
+    })
+
+    it('should reject deep parent escape', () => {
+      expect(() => validateWithinBoundary('../../../etc/passwd', '/var/workspace', path))
+        .toThrow(PathEscapeError)
+    })
+
+    it('should reject escape via complex path', () => {
+      expect(() => validateWithinBoundary('a/b/../../../../etc/passwd', '/var/workspace', path))
+        .toThrow(PathEscapeError)
+    })
+
+    it('should reject escape that goes to boundary parent', () => {
+      expect(() => validateWithinBoundary('..', '/var/workspace', path))
+        .toThrow(PathEscapeError)
+    })
+  })
+
+  describe('with path.posix (for remote/cross-platform)', () => {
+    it('should handle relative paths with posix', () => {
+      const result = validateWithinBoundary('file.txt', '/var/workspace', path.posix)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should handle absolute paths matching boundary with posix', () => {
+      const result = validateWithinBoundary('/var/workspace/file.txt', '/var/workspace', path.posix)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+
+    it('should treat non-matching absolute paths as relative with posix', () => {
+      const result = validateWithinBoundary('/other/file.txt', '/var/workspace', path.posix)
+      expect(result).toBe('/var/workspace/other/file.txt')
+    })
+
+    it('should reject escape attempts with posix', () => {
+      expect(() => validateWithinBoundary('../etc/passwd', '/var/workspace', path.posix))
+        .toThrow(PathEscapeError)
+    })
+  })
+
+  describe('scoped boundaries (non-root)', () => {
+    it('should work with scope boundary', () => {
+      const result = validateWithinBoundary('file.txt', 'users/user1', path.posix)
+      expect(result).toBe('users/user1/file.txt')
+    })
+
+    it('should handle absolute path within scope', () => {
+      // When scope is 'users/user1', an absolute path /users/user1/file should match
+      const result = validateWithinBoundary('/users/user1/file.txt', 'users/user1', path.posix)
+      expect(result).toBe('/users/user1/file.txt')
+    })
+
+    it('should treat non-matching absolute as relative to scope', () => {
+      const result = validateWithinBoundary('/file.txt', 'users/user1', path.posix)
+      expect(result).toBe('users/user1/file.txt')
+    })
+
+    it('should reject scope escape', () => {
+      expect(() => validateWithinBoundary('../user2/secret', 'users/user1', path.posix))
+        .toThrow(PathEscapeError)
+    })
+
+    it('should reject escape to parent of scope', () => {
+      expect(() => validateWithinBoundary('../../etc', 'users/user1', path.posix))
+        .toThrow(PathEscapeError)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty string as current directory', () => {
+      const result = validateWithinBoundary('', '/var/workspace', path)
+      expect(result).toBe('/var/workspace')
+    })
+
+    it('should handle multiple slashes in path', () => {
+      const result = validateWithinBoundary('a//b///c', '/var/workspace', path)
+      expect(result).toBe('/var/workspace/a/b/c')
+    })
+
+    it('should handle trailing slashes in boundary', () => {
+      const result = validateWithinBoundary('file.txt', '/var/workspace/', path)
+      expect(result).toBe('/var/workspace/file.txt')
+    })
+  })
+})
+
+describe('validateAbsoluteWithinRoot', () => {
+  it('should accept path within root', () => {
+    expect(() => validateAbsoluteWithinRoot('/var/workspace/file.txt', '/var/workspace', path))
+      .not.toThrow()
+  })
+
+  it('should accept path equal to root', () => {
+    expect(() => validateAbsoluteWithinRoot('/var/workspace', '/var/workspace', path))
+      .not.toThrow()
+  })
+
+  it('should reject path outside root', () => {
+    expect(() => validateAbsoluteWithinRoot('/etc/passwd', '/var/workspace', path))
+      .toThrow(PathEscapeError)
+  })
+
+  it('should reject path that looks similar but is outside', () => {
+    expect(() => validateAbsoluteWithinRoot('/var/workspace2/file', '/var/workspace', path))
+      .toThrow(PathEscapeError)
+  })
+
+  it('should reject parent of root', () => {
+    expect(() => validateAbsoluteWithinRoot('/var', '/var/workspace', path))
+      .toThrow(PathEscapeError)
+  })
+})

--- a/typescript/tests/unit/transports/WebSocketSSHTransport.test.ts
+++ b/typescript/tests/unit/transports/WebSocketSSHTransport.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+
+// Mock ws module
+vi.mock('ws', () => {
+  const MockWebSocket = vi.fn()
+  MockWebSocket.OPEN = 1
+  MockWebSocket.CLOSED = 3
+  return { default: MockWebSocket, WebSocket: MockWebSocket }
+})
+
+// Mock ssh2 module
+vi.mock('ssh2', () => ({
+  Client: vi.fn()
+}))
+
+import { WebSocketSSHTransport } from '../../../src/backends/transports/WebSocketSSHTransport.js'
+import WebSocket from 'ws'
+import { Client as SSHClient } from 'ssh2'
+
+// Helper to create a mock WebSocket with configurable behavior
+function createMockWebSocket(options: {
+  openBehavior?: 'success' | 'error' | 'timeout'
+  readyState?: number
+} = {}) {
+  const ws = new EventEmitter() as EventEmitter & {
+    send: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+    readyState: number
+  }
+  ws.send = vi.fn((data, callback) => callback?.())
+  ws.close = vi.fn()
+  ws.readyState = options.readyState ?? 1 // OPEN
+
+  // Trigger open or error based on behavior
+  if (options.openBehavior === 'error') {
+    setTimeout(() => ws.emit('error', new Error('Connection refused')), 0)
+  } else if (options.openBehavior !== 'timeout') {
+    setTimeout(() => ws.emit('open'), 0)
+  }
+
+  return ws
+}
+
+// Helper to create a mock SSH client
+function createMockSSHClient(options: {
+  connectBehavior?: 'success' | 'error'
+  execResults?: { stdout: string; stderr?: string; code: number }
+} = {}) {
+  const client = new EventEmitter() as EventEmitter & {
+    connect: ReturnType<typeof vi.fn>
+    exec: ReturnType<typeof vi.fn>
+    sftp: ReturnType<typeof vi.fn>
+    end: ReturnType<typeof vi.fn>
+  }
+
+  client.connect = vi.fn(() => {
+    if (options.connectBehavior === 'error') {
+      setTimeout(() => client.emit('error', new Error('SSH handshake failed')), 0)
+    } else {
+      setTimeout(() => client.emit('ready'), 0)
+    }
+  })
+
+  client.exec = vi.fn((command: string, callback: Function) => {
+    const channel = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
+    channel.stderr = new EventEmitter()
+    const result = options.execResults ?? { stdout: '', stderr: '', code: 0 }
+
+    setTimeout(() => {
+      if (result.stdout) channel.emit('data', Buffer.from(result.stdout))
+      if (result.stderr) channel.stderr.emit('data', Buffer.from(result.stderr))
+      channel.emit('close', result.code)
+    }, 0)
+
+    callback(null, channel)
+  })
+
+  client.sftp = vi.fn((callback) => {
+    const sftp = new EventEmitter()
+    callback(null, sftp)
+  })
+
+  client.end = vi.fn()
+
+  return client
+}
+
+describe('WebSocketSSHTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Configuration', () => {
+    it('should initialize with config and report disconnected', () => {
+      const transport = new WebSocketSSHTransport({
+        host: 'remote.example.com',
+        port: 3001,
+        authToken: 'secret-token'
+      })
+
+      expect(transport.connected).toBe(false)
+    })
+
+    it('should use default path and timeout values', () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      // Trigger connection to verify URL construction
+      transport.connect().catch(() => {})
+
+      // Should use default /ssh path
+      expect(WebSocket).toHaveBeenCalledWith(expect.stringContaining('/ssh'))
+    })
+  })
+
+  describe('Connection', () => {
+    it('should connect via WebSocket then establish SSH session', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001,
+        authToken: 'test-token'
+      })
+
+      await transport.connect()
+
+      expect(transport.connected).toBe(true)
+      expect(WebSocket).toHaveBeenCalledWith(
+        expect.stringContaining('ws://example.com:3001/ssh?token=test-token')
+      )
+      expect(mockSsh.connect).toHaveBeenCalled()
+    })
+
+    it('should not reconnect if already connected', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      await transport.connect() // Second call should be no-op
+
+      expect(WebSocket).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle WebSocket connection errors', async () => {
+      const mockWs = createMockWebSocket({ openBehavior: 'error' })
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await expect(transport.connect()).rejects.toThrow('Connection refused')
+      expect(transport.connected).toBe(false)
+    })
+
+    it('should handle SSH handshake errors', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient({ connectBehavior: 'error' })
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await expect(transport.connect()).rejects.toThrow('SSH handshake failed')
+    })
+
+    it('should use wss:// for port 443', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 443
+      })
+
+      await transport.connect()
+
+      expect(WebSocket).toHaveBeenCalledWith(expect.stringContaining('wss://'))
+    })
+  })
+
+  describe('Command Execution', () => {
+    it('should execute command and return stdout/stderr/code', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient({
+        execResults: { stdout: 'hello world\n', stderr: '', code: 0 }
+      })
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      const result = await transport.exec('echo hello world')
+
+      expect(result.stdout).toBe('hello world\n')
+      expect(result.code).toBe(0)
+    })
+
+    it('should capture stderr and non-zero exit codes', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient({
+        execResults: { stdout: '', stderr: 'error message', code: 1 }
+      })
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      const result = await transport.exec('false')
+
+      expect(result.stderr).toBe('error message')
+      expect(result.code).toBe(1)
+    })
+
+    it('should throw when executing without connection', async () => {
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await expect(transport.exec('echo test')).rejects.toThrow('Not connected')
+    })
+  })
+
+  describe('SFTP', () => {
+    it('should get SFTP session', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      const sftp = await transport.getSFTP()
+
+      expect(sftp).toBeDefined()
+      expect(mockSsh.sftp).toHaveBeenCalled()
+    })
+
+    it('should reuse existing SFTP session', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      await transport.getSFTP()
+      await transport.getSFTP()
+
+      expect(mockSsh.sftp).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Disconnect', () => {
+    it('should clean up resources on disconnect', async () => {
+      const mockWs = createMockWebSocket()
+      vi.mocked(WebSocket).mockImplementation(() => mockWs as any)
+
+      const mockSsh = createMockSSHClient()
+      vi.mocked(SSHClient).mockImplementation(() => mockSsh as any)
+
+      const transport = new WebSocketSSHTransport({
+        host: 'example.com',
+        port: 3001
+      })
+
+      await transport.connect()
+      expect(transport.connected).toBe(true)
+
+      await transport.disconnect()
+      expect(transport.connected).toBe(false)
+      expect(mockSsh.end).toHaveBeenCalled()
+      expect(mockWs.close).toHaveBeenCalled()
+    })
+  })
+})

--- a/typescript/tests/unit/transports/WebSocketSSHTransport.test.ts
+++ b/typescript/tests/unit/transports/WebSocketSSHTransport.test.ts
@@ -9,14 +9,14 @@ vi.mock('ws', () => {
   return { default: MockWebSocket, WebSocket: MockWebSocket }
 })
 
-// Mock ssh2 module
-vi.mock('ssh2', () => ({
-  Client: vi.fn()
+// Mock our SSH2 wrapper
+vi.mock('../../../src/utils/ssh2.js', () => ({
+  SSH2Client: vi.fn()
 }))
 
 import { WebSocketSSHTransport } from '../../../src/backends/transports/WebSocketSSHTransport.js'
 import WebSocket from 'ws'
-import { Client as SSHClient } from 'ssh2'
+import { SSH2Client as SSHClient } from '../../../src/utils/ssh2.js'
 
 // Helper to create a mock WebSocket with configurable behavior
 function createMockWebSocket(options: {


### PR DESCRIPTION
## Description
This PR migrates the default SSH option from conventional sshd based to SSH over WebSockets, which enables serving SSH over a ws connection. This is easier to manage for distributed deploys on k8s (and likely other deploy solutions) since exposing SSH ports directly can be hairy.

Also fixes up some path handling to standardize path conventions across all backend types 