### PR TITLE
feat: Move mcp client close management to the backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Agent Backend - Claude Development Guide
 
-Secure, isolated backend for AI agents supporting code execution, file operations, and persistent storage. **Formerly AgentBackend.**
+Secure, isolated backend for AI agents supporting code execution, file operations, and persistent storage.
 
 ## Project Structure
 
@@ -45,6 +45,7 @@ pnpm-workspace.yaml            # TypeScript workspace config
 2. **Pooling** - `BackendPoolManager` reuses connections for stateless servers
 3. **MCP Integration** - `.getMCPClient()` exposes tools via Model Context Protocol
 4. **Security Layers** - Command validation, path escape prevention, isolation modes
+5. **Resource Lifecycle** - `destroy()` auto-closes tracked MCP clients/transports; `trackCloseable()` registers external resources
 
 ### Isolation Modes
 - `'auto'` - Detects best available (bubblewrap → software)
@@ -149,6 +150,8 @@ Language-specific: `make build-typescript`, `make test-python`
 - BackendPoolManager supports per-request config overrides
 - AgentBackendMCPServer uses duck typing for exec capability detection
 - Single adaptive server replaces separate LocalFilesystem/Remote/Memory server classes
+- `destroy()` closes all tracked closeables (MCP clients, transports) before tearing down the backend
+- Scoped backends delegate `trackCloseable()` to their parent backend
 
 ## Key Files to Understand
 

--- a/examples/TSBasic/index.ts
+++ b/examples/TSBasic/index.ts
@@ -86,7 +86,6 @@ async function main() {
     await runChat({ model: MODEL, tools })
   } finally {
     console.log('\nShutting down...')
-    await mcpClient.close()
     await backend.destroy()
   }
 }

--- a/typescript/CLAUDE.md
+++ b/typescript/CLAUDE.md
@@ -128,6 +128,7 @@ tests/unit/                     # Unit tests (Vitest)
 2. **Scoping for isolation** - Multi-tenancy via `.scope()`
 3. **Connection pooling** - `BackendPoolManager` for stateless servers
 4. **MCP integration** - `.getMCPClient()` for protocol support
+5. **Resource lifecycle** - `destroy()` auto-closes tracked MCP clients/transports; `trackCloseable()` registers external resources
 
 ## Usage Examples
 
@@ -270,7 +271,8 @@ await mcp.callTool({
   arguments: { command: 'npm install' }
 })
 
-await mcp.close()
+// destroy() auto-closes MCP clients, transports, and backend resources
+await backend.destroy()
 ```
 
 ### Scoped MCP
@@ -286,6 +288,7 @@ const mcp = await backend.getMCPClient('users/user123/projects/my-app')
 3. **Path escapes** - Absolute paths are treated as relative to scope, `..` blocked if escapes
 4. **BackendType enum** - Values are `'local-filesystem'`, `'remote-filesystem'`, `'memory'` (not `'local'`, `'remote'`)
 5. **MemoryBackend.exec()** - Throws NotImplementedError, not supported
+6. **Scoped trackCloseable** - Scoped backends delegate `trackCloseable()` to their parent, so resources are closed when the parent is destroyed
 
 ## Files Safe to Delete
 

--- a/typescript/src/adapters/VercelAIAdapter.ts
+++ b/typescript/src/adapters/VercelAIAdapter.ts
@@ -22,7 +22,7 @@
  * })
  *
  * // Remember to close when done
- * await mcpClient.close()
+ * await backend.destroy()
  * ```
  */
 
@@ -98,6 +98,7 @@ export class VercelAIAdapter {
         createMCPClient({ transport }),
         timeoutPromise
       ])
+      this.backend.trackCloseable(client)
       return client
     } catch (error) {
       // Enhance error message for common issues

--- a/typescript/src/backends/ScopedFilesystemBackend.ts
+++ b/typescript/src/backends/ScopedFilesystemBackend.ts
@@ -77,6 +77,10 @@ export class ScopedFilesystemBackend<T extends FileBasedBackend = FileBasedBacke
     return this.parent.onStatusChange(cb)
   }
 
+  trackCloseable(closeable: { close(): Promise<void> }): void {
+    this.parent.trackCloseable(closeable)
+  }
+
   /**
    * Validate that scope path doesn't escape parent
    * Uses shared validation utility for DRY

--- a/typescript/src/backends/ScopedMemoryBackend.ts
+++ b/typescript/src/backends/ScopedMemoryBackend.ts
@@ -41,6 +41,10 @@ export class ScopedMemoryBackend<T extends FileBasedBackend = FileBasedBackend> 
     return this.parent.onStatusChange(cb)
   }
 
+  trackCloseable(closeable: { close(): Promise<void> }): void {
+    this.parent.trackCloseable(closeable)
+  }
+
   constructor(
     parent: T,
     scopePath: string,

--- a/typescript/src/backends/types.ts
+++ b/typescript/src/backends/types.ts
@@ -84,6 +84,13 @@ export interface Backend {
   getMCPClient(): Promise<Client>
 
   /**
+   * Track a closeable resource tied to this backend's lifecycle.
+   * Tracked resources are automatically closed when destroy() is called.
+   * @param closeable - Any object with a close() method (e.g., MCP Client, Transport)
+   */
+  trackCloseable(closeable: { close(): Promise<void> }): void
+
+  /**
    * Cleanup resources
    */
   destroy(): Promise<void>

--- a/typescript/src/mcp/client.ts
+++ b/typescript/src/mcp/client.ts
@@ -33,9 +33,9 @@ export interface AgentBeMCPClientOptions {
  *   name: 'read_text_file',
  *   arguments: { path: 'package.json' }
  * })
- *
- * // When done
- * await mcpClient.close()
+ * 
+ * // Client must be closed to terminate the connection (this should generally be handled by destroying the backend instance)
+ * mcpClient.close()
  * ```
  */
 /**

--- a/typescript/tests/unit/backends/LocalFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/LocalFilesystemBackend.test.ts
@@ -718,4 +718,46 @@ describe('LocalFilesystemBackend (Unit Tests)', () => {
       await expect(backend.destroy()).resolves.toBeUndefined()
     })
   })
+
+  describe('Closeable Tracking', () => {
+    it('should close all tracked closeables on destroy', async () => {
+      const closeable1 = { close: vi.fn().mockResolvedValue(undefined) }
+      const closeable2 = { close: vi.fn().mockResolvedValue(undefined) }
+
+      backend.trackCloseable(closeable1)
+      backend.trackCloseable(closeable2)
+
+      await backend.destroy()
+
+      expect(closeable1.close).toHaveBeenCalledTimes(1)
+      expect(closeable2.close).toHaveBeenCalledTimes(1)
+      expect(backend.status).toBe('destroyed')
+    })
+
+    it('should tolerate errors from closeable.close()', async () => {
+      const closeable1 = { close: vi.fn().mockRejectedValue(new Error('close failed')) }
+      const closeable2 = { close: vi.fn().mockResolvedValue(undefined) }
+
+      backend.trackCloseable(closeable1)
+      backend.trackCloseable(closeable2)
+
+      await expect(backend.destroy()).resolves.toBeUndefined()
+
+      expect(closeable1.close).toHaveBeenCalledTimes(1)
+      expect(closeable2.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('should clear closeables set after destroy', async () => {
+      const closeable = { close: vi.fn().mockResolvedValue(undefined) }
+      backend.trackCloseable(closeable)
+
+      await backend.destroy()
+      expect(closeable.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle destroy with no tracked closeables', async () => {
+      await expect(backend.destroy()).resolves.toBeUndefined()
+      expect(backend.status).toBe('destroyed')
+    })
+  })
 })

--- a/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
+++ b/typescript/tests/unit/backends/ScopedFilesystemBackend.test.ts
@@ -340,4 +340,31 @@ describe('ScopedFilesystemBackend (Unit Tests)', () => {
       expect(scoped.status).toBe('connected')
     })
   })
+
+  describe('Closeable Tracking Delegation', () => {
+    it('should delegate trackCloseable to parent', () => {
+      const closeable = { close: vi.fn().mockResolvedValue(undefined) }
+
+      scoped.trackCloseable(closeable)
+
+      expect(mockParent.trackCloseable).toHaveBeenCalledWith(closeable)
+    })
+
+    it('should delegate trackCloseable from nested scope to root parent', () => {
+      const nested = scoped.scope('projects/proj1')
+      const closeable = { close: vi.fn().mockResolvedValue(undefined) }
+
+      nested.trackCloseable(closeable)
+
+      expect(mockParent.trackCloseable).toHaveBeenCalledWith(closeable)
+    })
+  })
+
+  describe('Destroy', () => {
+    it('should call parent.onChildDestroyed on destroy', async () => {
+      await scoped.destroy()
+
+      expect(mockParent.onChildDestroyed).toHaveBeenCalledWith(scoped)
+    })
+  })
 })

--- a/typescript/tests/unit/helpers/mockFactories.ts
+++ b/typescript/tests/unit/helpers/mockFactories.ts
@@ -137,6 +137,7 @@ export function createMockFileBackend(overrides: Partial<FileBasedBackend> & { c
     getMCPTransport: vi.fn(),
     destroy: vi.fn().mockResolvedValue(undefined),
     onChildDestroyed: vi.fn().mockResolvedValue(undefined),
+    trackCloseable: vi.fn(),
     ...rest
   } as FileBasedBackend
 
@@ -172,6 +173,7 @@ export function createMockMemoryBackend(overrides: Partial<MemoryBackend> = {}):
     getMCPTransport: vi.fn(),
     destroy: vi.fn().mockResolvedValue(undefined),
     onChildDestroyed: vi.fn().mockResolvedValue(undefined),
+    trackCloseable: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
     delete: vi.fn().mockResolvedValue(undefined),
     clear: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description
Backends now manage the close internally so there's no need to call mcpClient.close() explicitly.