### PR TITLE
chore: release v0.8.9

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-backend"
-version = "0.8.8"
+version = "0.8.9"
 description = "Python bindings for Agent Backend"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-backend",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "A distributed filesystem backend for your AI agent in a single API, just like a database or storage system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to **v0.8.9** (patch)
- TypeScript `package.json` updated
- Python `pyproject.toml` synced

## Post-merge
CI will auto-publish to npm via the `publish` workflow.