### PR TITLE
chore: release v0.9.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           version: 9
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.11.1
 
       - name: Install dependencies
         working-directory: typescript
@@ -111,6 +111,8 @@ jobs:
         run: npm install -g opensdd
 
       - name: Publish OpenSDD spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: opensdd publish --branch "agent-backend/${{ needs.check-version.outputs.version }}"
 
   tag-release:

--- a/opensdd.json
+++ b/opensdd.json
@@ -4,7 +4,7 @@
   "depsDir": ".opensdd.deps",
   "publish": {
     "name": "agent-backend",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces",
     "specFormat": "0.1.0",
     "dependencies": []

--- a/python/agent_backend/__init__.py
+++ b/python/agent_backend/__init__.py
@@ -36,7 +36,7 @@ from agent_backend.types import (
     StatusChangeEvent,
 )
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 __all__ = [
     "ArrayOperationsLogger",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-backend"
-version = "0.9.1"
+version = "0.9.2"
 description = "A distributed, scalable filesystem backend for deep AI agents, backed by blob storage"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-backend",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A distributed filesystem backend for your AI agent in a single API, just like a database or storage system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to **v0.9.2** (patch)
- TypeScript `package.json` updated
- Python `pyproject.toml` + `__init__.py` synced

## Post-merge
After merging, manually trigger the **Publish Packages** workflow in GitHub Actions to publish to npm and PyPI.